### PR TITLE
Limit page style options to lined and blank backgrounds

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,19 +220,11 @@
         <div class="style-grid" role="list">
           <button class="style-option" type="button" data-page-style="blank">
             <span class="style-preview style-none" aria-hidden="true"></span>
-            <span class="style-label">None</span>
+            <span class="style-label">White</span>
           </button>
           <button class="style-option" type="button" data-page-style="red-blue">
             <span class="style-preview style-three-line" aria-hidden="true"></span>
             <span class="style-label">3-line</span>
-          </button>
-          <button class="style-option" type="button" data-page-style="squares">
-            <span class="style-preview style-grid" aria-hidden="true"></span>
-            <span class="style-label">Grid</span>
-          </button>
-          <button class="style-option" type="button" data-page-style="grey-dotted">
-            <span class="style-preview style-dots" aria-hidden="true"></span>
-            <span class="style-label">Dots</span>
           </button>
         </div>
       </div>

--- a/js/Controls.js
+++ b/js/Controls.js
@@ -23,9 +23,7 @@ const PEN_COLOUR_SWATCHES = [
 
 const PAGE_STYLE_DRAWERS = {
   blank: clearBackground,
-  'red-blue': drawRedBlueGuidelines,
-  squares: drawSquares,
-  'grey-dotted': drawGreyDottedLines
+  'red-blue': drawRedBlueGuidelines
 };
 
 export class Controls {
@@ -657,32 +655,6 @@ function withContext(ctx, drawFn) {
   }
 }
 
-function drawHorizontalLines(ctx, width, height, { spacing, colour, widthPx = 2, dash = [], offset = 0 }) {
-  withContext(ctx, () => {
-    ctx.clearRect(0, 0, width, height);
-    ctx.strokeStyle = colour;
-    ctx.lineWidth = widthPx;
-    ctx.setLineDash(dash);
-
-    for (let y = offset; y <= height; y += spacing) {
-      ctx.beginPath();
-      ctx.moveTo(0, y);
-      ctx.lineTo(width, y);
-      ctx.stroke();
-    }
-  });
-}
-
-function drawGreyDottedLines(ctx, width, height) {
-  drawHorizontalLines(ctx, width, height, {
-    spacing: 60,
-    colour: '#7a7a7a',
-    widthPx: 2,
-    dash: [10, 22],
-    offset: 40
-  });
-}
-
 function drawRedBlueGuidelines(ctx, width, height) {
   withContext(ctx, () => {
     ctx.clearRect(0, 0, width, height);
@@ -701,29 +673,6 @@ function drawRedBlueGuidelines(ctx, width, height) {
       ctx.strokeStyle = '#d8342c';
       ctx.moveTo(0, mid);
       ctx.lineTo(width, mid);
-      ctx.stroke();
-    }
-  });
-}
-
-function drawSquares(ctx, width, height) {
-  withContext(ctx, () => {
-    ctx.clearRect(0, 0, width, height);
-    const spacing = 70;
-    ctx.strokeStyle = '#1f4ea3';
-    ctx.lineWidth = 1.5;
-
-    for (let y = spacing; y <= height; y += spacing) {
-      ctx.beginPath();
-      ctx.moveTo(0, y);
-      ctx.lineTo(width, y);
-      ctx.stroke();
-    }
-
-    for (let x = spacing; x <= width; x += spacing) {
-      ctx.beginPath();
-      ctx.moveTo(x, 0);
-      ctx.lineTo(x, height);
       ctx.stroke();
     }
   });


### PR DESCRIPTION
## Summary
- limit the page style popover to white and 3-line guideline choices
- drop the unused drawing helpers for the removed background styles

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d33f2a88ac8331b576061f67d39b3a