### PR TITLE
Add collapsible toolbar in fullscreen

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -232,6 +232,7 @@ body {
   margin: 6px clamp(16px, 6vw, 48px) 0 auto;
   align-self: flex-end;
   color: var(--color-smoky-black);
+  --toolbar-toggle-visible: 56px;
 }
 
 .toolbar-inner {
@@ -319,6 +320,77 @@ body {
   cursor: not-allowed;
   pointer-events: none;
   box-shadow: none;
+}
+
+.toolbar-toggle__icon {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
+  transition: transform 0.3s ease;
+}
+
+#toolbarToggle {
+  display: none;
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translate(-50%, 0);
+  width: 52px;
+  height: 36px;
+  border-radius: 20px;
+  border: 2px solid rgba(10, 9, 3, 0.15);
+  background: #ffffff;
+  color: var(--color-smoky-black);
+  box-shadow: 0 6px 14px rgba(10, 9, 3, 0.18);
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  z-index: 2;
+}
+
+#toolbarToggle svg {
+  display: block;
+}
+
+#toolbarToggle:hover,
+#toolbarToggle:focus-visible {
+  transform: translate(-50%, -2px);
+  box-shadow: 0 10px 20px rgba(10, 9, 3, 0.24);
+  outline: none;
+  background: var(--color-smoky-black);
+  color: #ffffff;
+  border-color: #ffffff;
+}
+
+#toolbarToggle:active {
+  transform: translate(-50%, 0);
+  box-shadow: 0 4px 8px rgba(10, 9, 3, 0.24);
+}
+
+body.is-fullscreen #toolbarBottom {
+  position: fixed;
+  left: 50%;
+  bottom: 16px;
+  transform: translate(-50%, 0);
+  width: min(92vw, 920px);
+  margin: 0;
+  padding: 62px 24px 28px;
+  z-index: 1000;
+  transition: transform 0.3s ease;
+}
+
+body.is-fullscreen #toolbarToggle {
+  display: inline-flex;
+}
+
+body.is-fullscreen #toolbarBottom.is-collapsed {
+  transform: translate(-50%, calc(100% - var(--toolbar-toggle-visible)));
+}
+
+body.is-fullscreen #toolbarBottom.is-collapsed .toolbar-toggle__icon {
+  transform: rotate(180deg);
 }
 
 .btn.icon.is-active {
@@ -712,6 +784,11 @@ body {
 }
 
 @media (max-width: 640px) {
+  body.is-fullscreen #toolbarBottom {
+    width: min(96vw, 920px);
+    padding: 56px 16px 24px;
+  }
+
   #toolbarBottom {
     padding: 18px 16px 26px;
   }
@@ -737,5 +814,14 @@ body {
   .title-texts::before,
   .title-texts::after {
     animation: none;
+  }
+
+  body.is-fullscreen #toolbarBottom {
+    transition: none;
+  }
+
+  #toolbarToggle,
+  .toolbar-toggle__icon {
+    transition: none;
   }
 }

--- a/index.html
+++ b/index.html
@@ -85,6 +85,17 @@
       </div>
 
       <div id="toolbarBottom" role="toolbar" aria-label="Handwriting controls" class="disable-select">
+        <button
+          id="toolbarToggle"
+          class="toolbar-toggle"
+          type="button"
+          aria-label="Hide controls"
+          aria-expanded="true"
+        >
+          <svg class="toolbar-toggle__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M12 16.5 5.5 10l1.41-1.41L12 13.67l5.09-5.08L18.5 10z"></path>
+          </svg>
+        </button>
         <div class="toolbar-inner">
           <div class="toolbar-group toolbar-left" role="group" aria-label="Zoom and speed">
             <button class="btn icon" id="btnZoomOut" type="button" aria-label="Zoom out" title="Zoom out">

--- a/js/Controls.js
+++ b/js/Controls.js
@@ -77,6 +77,11 @@ export class Controls {
       : [];
     this.timerProgress = document.getElementById('timerProgress');
 
+    this.toolbarBottom = document.getElementById('toolbarBottom');
+    this.toolbarToggleButton = document.getElementById('toolbarToggle');
+    this.toolbarOriginalParent = this.toolbarBottom?.parentElement ?? null;
+    this.toolbarNextSibling = this.toolbarBottom?.nextSibling ?? null;
+
     this.uploadPenButton = document.getElementById('btnUploadPen');
     this.penImageInput = document.getElementById('inputPenImage');
 
@@ -101,6 +106,7 @@ export class Controls {
     this.setupAuxiliaryButtons();
     this.setupCookieBanner();
     this.setupDateDisplay();
+    this.setupFullscreenBehaviour();
     this.applyToolbarLayoutVersion();
     this.applyInitialState();
   }
@@ -358,6 +364,78 @@ export class Controls {
         }
       });
     }
+  }
+
+  setupFullscreenBehaviour() {
+    if (typeof document === 'undefined' || !this.toolbarBottom) {
+      return;
+    }
+
+    const setCollapsedState = collapsed => {
+      if (!this.toolbarToggleButton) {
+        return;
+      }
+      const expanded = !collapsed;
+      this.toolbarToggleButton.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+      this.toolbarToggleButton.setAttribute('aria-label', expanded ? 'Hide controls' : 'Show controls');
+    };
+
+    setCollapsedState(false);
+
+    const restoreToolbarPosition = () => {
+      if (!this.toolbarOriginalParent || !this.toolbarBottom) {
+        return;
+      }
+
+      if (this.toolbarBottom.parentElement === this.toolbarOriginalParent) {
+        return;
+      }
+
+      if (this.toolbarNextSibling && this.toolbarNextSibling.parentNode === this.toolbarOriginalParent) {
+        this.toolbarOriginalParent.insertBefore(this.toolbarBottom, this.toolbarNextSibling);
+      } else {
+        this.toolbarOriginalParent.appendChild(this.toolbarBottom);
+      }
+    };
+
+    const handleFullscreenChange = () => {
+      const fullscreenElement = document.fullscreenElement ?? document.webkitFullscreenElement ?? null;
+      const isWriterFullscreen = fullscreenElement === this.writerContainer;
+      const isDocumentFullscreen =
+        fullscreenElement === document.documentElement || fullscreenElement === document.body;
+      const isAppFullscreen = isWriterFullscreen || isDocumentFullscreen;
+      const body = document.body;
+
+      if (body) {
+        body.classList.toggle('is-fullscreen', isAppFullscreen);
+      }
+
+      if (isWriterFullscreen) {
+        if (this.writerContainer && this.toolbarBottom.parentElement !== this.writerContainer) {
+          this.writerContainer.appendChild(this.toolbarBottom);
+        }
+      } else {
+        restoreToolbarPosition();
+        this.toolbarBottom.classList.remove('is-collapsed');
+        setCollapsedState(false);
+      }
+    };
+
+    if (this.toolbarToggleButton) {
+      this.toolbarToggleButton.addEventListener('click', () => {
+        if (!document.body?.classList.contains('is-fullscreen')) {
+          return;
+        }
+        const isCollapsed = this.toolbarBottom.classList.toggle('is-collapsed');
+        setCollapsedState(isCollapsed);
+      });
+    }
+
+    ['fullscreenchange', 'webkitfullscreenchange'].forEach(eventName => {
+      document.addEventListener(eventName, handleFullscreenChange);
+    });
+
+    handleFullscreenChange();
   }
 
   setupCookieBanner() {


### PR DESCRIPTION
## Summary
- add a dedicated toggle arrow so the toolbar can slide open and closed while fullscreen
- style the toolbar for fullscreen overlay placement with responsive spacing and motion preferences
- move the toolbar into the fullscreen container and manage collapse/expand state during fullscreen changes

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d34ac8bf60833187f7b9f0f1f05986