### PR TITLE
Add control to remove custom pen image

### DIFF
--- a/assets/icons.svg
+++ b/assets/icons.svg
@@ -57,6 +57,10 @@
     <path d="M8 9l4-4 4 4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M5 19h14" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
   </symbol>
+  <symbol id="close" viewBox="0 0 24 24">
+    <line x1="7" y1="7" x2="17" y2="17" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+    <line x1="17" y1="7" x2="7" y2="17" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+  </symbol>
   <symbol id="timer" viewBox="0 0 24 24">
     <circle cx="12" cy="13" r="7" fill="none" stroke="currentColor" stroke-width="2" />
     <line x1="12" y1="13" x2="12" y2="9" stroke="currentColor" stroke-width="2" stroke-linecap="round" />

--- a/index.html
+++ b/index.html
@@ -175,6 +175,16 @@
               <svg aria-hidden="true"><use href="assets/icons.svg#upload"></use></svg>
             </button>
             <button
+              class="btn icon is-disabled"
+              id="btnRemovePenImage"
+              type="button"
+              aria-label="Remove custom pen image"
+              title="Remove custom pen image"
+              disabled
+            >
+              <svg aria-hidden="true"><use href="assets/icons.svg#close"></use></svg>
+            </button>
+            <button
               class="btn icon"
               id="btnTimer"
               type="button"

--- a/js/Controls.js
+++ b/js/Controls.js
@@ -82,6 +82,7 @@ export class Controls {
     this.timerProgress = document.getElementById('timerProgress');
 
     this.uploadPenButton = document.getElementById('btnUploadPen');
+    this.removePenImageButton = document.getElementById('btnRemovePenImage');
     this.penImageInput = document.getElementById('inputPenImage');
 
     this.cookiePopup = document.getElementById('cookiePopup');
@@ -273,6 +274,8 @@ export class Controls {
     if (storedPageColour) {
       this.userData.userSettings.selectedPageColour = storedPageColour;
     }
+
+    this.setCustomPenImageState(Boolean(this.userData.userSettings.customPenImageSrc));
   }
 
   setupPenControls() {
@@ -305,6 +308,8 @@ export class Controls {
         this.penImageInput.click();
       });
     }
+
+    this.setCustomPenImageState(Boolean(this.userData.userSettings.customPenImageSrc));
   }
 
   setupPageControls() {
@@ -458,6 +463,14 @@ export class Controls {
 
     if (persist) {
       this.userData.saveToLocalStorage();
+    }
+  }
+
+  setCustomPenImageState(hasCustomImage) {
+    const isEnabled = Boolean(hasCustomImage);
+    if (this.removePenImageButton) {
+      this.removePenImageButton.disabled = !isEnabled;
+      this.removePenImageButton.classList.toggle('is-disabled', !isEnabled);
     }
   }
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-import { UserData } from './UserData.js';
+import { UserData, DEFAULT_SETTINGS } from './UserData.js';
 import { Controls } from './Controls.js';
 import { Point } from './Point.js';
 import { DrawnLine } from './DrawnLine.js';
@@ -120,12 +120,17 @@ function setupEventListeners() {
           window.localStorage.setItem('pen.imageSrc', dataUrl);
         }
         userData.saveToLocalStorage();
+        controls.setCustomPenImageState(true);
       }
     } catch (error) {
       console.warn('Unable to load custom pen image.', error);
     } finally {
       event.target.value = '';
     }
+  });
+
+  controls.removePenImageButton?.addEventListener('click', async () => {
+    await resetPenImageToDefault();
   });
 
   controls.rewriterCanvas.addEventListener('touchstart', event => {
@@ -355,6 +360,27 @@ function computePenScale(penSize) {
 
 function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function resetPenImageToDefault() {
+  const defaultImage = await safeLoadPenImage(DEFAULT_PEN_IMAGE_SRC);
+  if (!defaultImage) {
+    return;
+  }
+
+  currentPenImage = defaultImage;
+  userData.userSettings.customPenImageSrc = '';
+  userData.userSettings.penImageScale = DEFAULT_SETTINGS.penImageScale;
+
+  if (typeof window !== 'undefined' && window.localStorage) {
+    window.localStorage.setItem('pen.imageSrc', '');
+    window.localStorage.setItem('pen.imageScale', String(DEFAULT_SETTINGS.penImageScale));
+  }
+
+  customPenScale = clamp(userData.userSettings.penImageScale ?? DEFAULT_SETTINGS.penImageScale, 0.1, 5);
+  userData.saveToLocalStorage();
+  controls.setCustomPenImageState(false);
+  rewriterMaskContext.clearRect(0, 0, controls.rewriterMaskCanvas.width, controls.rewriterMaskCanvas.height);
 }
 
 async function safeLoadPenImage(src) {


### PR DESCRIPTION
## Summary
- add a toolbar control to remove a custom pen image and return to the default cursor
- manage the new control state in Controls and main logic so the default pen image is reloaded and stored settings cleared
- add a close icon asset used by the removal control

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d35295fa848331b65d2bb00661ee0e