### PR TITLE
Add teaching text overlay and freeze controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -256,6 +256,265 @@ body {
   justify-content: center;
 }
 
+.toolbar-group.toolbar-teach {
+  flex: 1 1 100%;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
+  background: rgba(255, 255, 255, 0.74);
+  border-radius: 16px;
+  padding: 12px 16px 16px;
+  box-shadow: inset 0 0 0 1px rgba(10, 9, 3, 0.08);
+}
+
+.teach-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.teach-label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--color-smoky-black);
+}
+
+.teach-input-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.teach-input {
+  flex: 1 1 240px;
+  min-width: 180px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 2px solid rgba(10, 9, 3, 0.15);
+  background: #ffffff;
+  font-size: 1rem;
+  font-family: inherit;
+  color: var(--color-smoky-black);
+  box-shadow: 0 4px 10px rgba(10, 9, 3, 0.12);
+  user-select: text;
+}
+
+.teach-input:focus {
+  outline: none;
+  border-color: var(--color-ut-orange);
+  box-shadow: 0 0 0 3px rgba(255, 130, 0, 0.2);
+}
+
+.teach-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 2px solid rgba(10, 9, 3, 0.1);
+  background: linear-gradient(180deg, var(--color-ut-orange) 0%, var(--color-aerospace-orange) 100%);
+  color: #fff;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  box-shadow: 0 6px 14px rgba(10, 9, 3, 0.18);
+  transition: transform 0.12s ease, box-shadow 0.12s ease, filter 0.18s ease;
+  min-width: 92px;
+  appearance: none;
+}
+
+.teach-button:hover,
+.teach-button:focus-visible {
+  outline: none;
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(10, 9, 3, 0.22);
+  filter: brightness(1.05);
+}
+
+.teach-button:active {
+  transform: translateY(0);
+  box-shadow: 0 4px 10px rgba(10, 9, 3, 0.2);
+}
+
+.teach-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+}
+
+.teach-button__arrow {
+  font-size: 1.1em;
+  line-height: 1;
+}
+
+.teach-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-start;
+  pointer-events: auto;
+  user-select: none;
+}
+
+.teach-preview__line {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.teach-preview__letter {
+  position: relative;
+  min-width: 28px;
+  min-height: 28px;
+  padding: 6px 8px;
+  border-radius: 10px;
+  border: 1px solid rgba(10, 9, 3, 0.12);
+  background: rgba(255, 255, 255, 0.85);
+  font-size: 1.1rem;
+  font-family: "KG Primary", "Comic Sans MS", "Comic Sans", cursive;
+  color: var(--color-smoky-black);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+  appearance: none;
+}
+
+.teach-preview__space {
+  display: inline-block;
+  min-width: 20px;
+  min-height: 28px;
+}
+
+.teach-preview__letter:hover,
+.teach-preview__letter:focus-visible {
+  outline: none;
+  transform: translateY(-1px);
+  box-shadow: 0 6px 14px rgba(10, 9, 3, 0.16);
+}
+
+.teach-preview__letter.is-revealed {
+  background: rgba(255, 244, 213, 0.95);
+}
+
+.teach-preview__letter.is-frozen {
+  border-color: var(--color-ut-orange);
+  box-shadow: 0 0 0 2px rgba(255, 130, 0, 0.2);
+}
+
+.teach-preview__letter[disabled] {
+  cursor: default;
+  opacity: 0.55;
+  box-shadow: none;
+}
+
+.teach-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(18px, 4vw, 48px);
+  pointer-events: none;
+  z-index: 2;
+}
+
+.teach-overlay.is-hidden {
+  opacity: 0;
+  visibility: hidden;
+}
+
+.teach-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(18px, 2.5vw, 36px);
+  transform-origin: center;
+}
+
+.teach-line {
+  display: flex;
+  gap: clamp(12px, 2vw, 28px);
+}
+
+.teach-letter {
+  position: relative;
+  font-size: clamp(64px, 12vw, 120px);
+  line-height: 1;
+  font-family: "KG Primary", "Comic Sans MS", "Comic Sans", cursive;
+  color: #111111;
+}
+
+.teach-letter .teach-placeholder,
+.teach-letter .teach-char {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  min-width: 0.7em;
+}
+
+.teach-letter .teach-placeholder {
+  opacity: 1;
+}
+
+.teach-letter.is-revealed .teach-placeholder {
+  opacity: 0;
+}
+
+.teach-letter .teach-char {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  opacity: 0;
+  transform: translateY(6%);
+}
+
+.teach-letter.is-revealed .teach-char {
+  opacity: 1;
+}
+
+.teach-letter--space .teach-placeholder,
+.teach-letter--space .teach-char {
+  min-width: clamp(32px, 3vw, 48px);
+}
+
+.teach-letter--space .teach-placeholder {
+  opacity: 0;
+}
+
+.teach-letter--uppercase,
+.teach-letter--descender {
+  color: #d8342c;
+}
+
+.teach-letter--period {
+  color: #1e4dd8;
+}
+
+.teach-letter--default,
+.teach-letter--lowercase {
+  color: #111111;
+}
+
+.teach-letter--punctuation {
+  color: #1e4dd8;
+}
+
+.teach-letter--number {
+  color: #d8342c;
+}
+
+.teach-letter--other {
+  color: #111111;
+}
 .toolbar-group.toolbar-left,
 .toolbar-group.toolbar-right {
   flex: 1 1 auto;
@@ -705,6 +964,27 @@ body {
   .toolbar-group.toolbar-right,
   .toolbar-group.toolbar-centre {
     flex: 1 1 100%;
+    justify-content: center;
+  }
+
+  .toolbar-group.toolbar-teach {
+    padding: 10px 12px 14px;
+  }
+
+  .teach-input-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .teach-button {
+    width: 100%;
+  }
+
+  .teach-preview {
+    align-items: stretch;
+  }
+
+  .teach-preview__line {
     justify-content: center;
   }
 

--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
           <canvas id="writerLines" width="1200" height="600"></canvas>
           <canvas id="writer" width="1200" height="600"></canvas>
           <canvas id="writerMask" width="1200" height="600"></canvas>
+          <div id="teachOverlay" class="teach-overlay" aria-live="polite"></div>
         </div>
 
         <div id="boardDate" aria-label="Date" role="button" tabindex="0">Loading date…</div>
@@ -118,6 +119,37 @@
             <button class="btn icon btn-primary" id="btnRewrite" type="button" aria-label="Rewrite" title="Rewrite" aria-pressed="false">
               <svg aria-hidden="true"><use href="assets/icons.svg#play"></use></svg>
             </button>
+          </div>
+
+          <div class="toolbar-group toolbar-teach" role="group" aria-label="Teaching text controls">
+            <div class="teach-field">
+              <label class="teach-label" for="teachTextInput">Practice text</label>
+              <div class="teach-input-row">
+                <input
+                  id="teachTextInput"
+                  class="teach-input"
+                  type="text"
+                  placeholder="Type a sentence for the board"
+                  autocomplete="off"
+                />
+                <button class="teach-button" id="btnTeach" type="button">Teach</button>
+                <button class="teach-button" id="btnTeachNext" type="button" disabled>
+                  Next
+                  <span aria-hidden="true" class="teach-button__arrow">➜</span>
+                </button>
+              </div>
+            </div>
+            <div class="teach-field">
+              <label class="teach-label" for="freezeLettersInput">Freeze letters</label>
+              <input
+                id="freezeLettersInput"
+                class="teach-input"
+                type="text"
+                placeholder="Enter letters to keep visible"
+                autocomplete="off"
+              />
+            </div>
+            <div class="teach-preview" id="teachPreview" aria-label="Sentence letter controls"></div>
           </div>
 
           <div class="toolbar-group toolbar-right" role="group" aria-label="Drawing controls">

--- a/js/main.js
+++ b/js/main.js
@@ -5,6 +5,7 @@ import { DrawnLine } from './DrawnLine.js';
 import { PenOptions } from './PenOptions.js';
 import { clamp, getAssetUrl, loadImage } from './utils.js';
 import { TimerController } from './timer.js';
+import { TeachController } from './teach.js';
 
 const ICON_SPRITE_PATH = 'assets/icons.svg';
 const DEFAULT_PEN_IMAGE_SRC = getAssetUrl('icons/pen.svg');
@@ -46,6 +47,15 @@ await loadInitialPenImage();
 await drawStoredLines(rewriterContext, true);
 
 setupEventListeners();
+
+new TeachController({
+  overlay: document.getElementById('teachOverlay'),
+  textInput: document.getElementById('teachTextInput'),
+  teachButton: document.getElementById('btnTeach'),
+  nextButton: document.getElementById('btnTeachNext'),
+  freezeInput: document.getElementById('freezeLettersInput'),
+  previewContainer: document.getElementById('teachPreview')
+});
 
 async function loadInitialPenImage() {
   const storedSrc = userData.userSettings.customPenImageSrc;

--- a/js/teach.js
+++ b/js/teach.js
@@ -1,0 +1,435 @@
+const DESCENDER_CHARACTERS = new Set(['g', 'j', 'p', 'q', 'y']);
+const PUNCTUATION_REGEX = /^[!?;:,]$/;
+
+export class TeachController {
+  constructor({
+    overlay,
+    textInput,
+    teachButton,
+    nextButton,
+    freezeInput,
+    previewContainer
+  }) {
+    this.overlay = overlay ?? null;
+    this.textInput = textInput ?? null;
+    this.teachButton = teachButton ?? null;
+    this.nextButton = nextButton ?? null;
+    this.freezeInput = freezeInput ?? null;
+    this.previewContainer = previewContainer ?? null;
+
+    this.overlayContent = null;
+    this.lines = [];
+    this.letters = [];
+    this.autoFrozenIndices = new Set();
+    this.manualFrozenIndices = new Set();
+    this.revealedByNext = new Set();
+    this.nextPointer = 0;
+
+    this.handleTeach = this.handleTeach.bind(this);
+    this.handleNext = this.handleNext.bind(this);
+    this.handleFreezeInputChange = this.handleFreezeInputChange.bind(this);
+    this.handlePreviewClick = this.handlePreviewClick.bind(this);
+
+    this.teachButton?.addEventListener('click', this.handleTeach);
+    this.nextButton?.addEventListener('click', this.handleNext);
+    this.freezeInput?.addEventListener('input', this.handleFreezeInputChange);
+    this.previewContainer?.addEventListener('click', this.handlePreviewClick);
+    this.textInput?.addEventListener('keydown', event => {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        this.handleTeach();
+      }
+    });
+
+    if (this.overlay && typeof ResizeObserver !== 'undefined') {
+      this.resizeObserver = new ResizeObserver(() => this.fitOverlay());
+      this.resizeObserver.observe(this.overlay);
+    }
+
+    window.addEventListener('resize', () => this.fitOverlay());
+
+    this.setOverlayHidden(true);
+    this.updateButtonStates();
+  }
+
+  handleTeach() {
+    const text = this.textInput?.value ?? '';
+    this.applyText(text);
+  }
+
+  handleNext() {
+    this.revealNextLetter();
+  }
+
+  handleFreezeInputChange() {
+    this.applyFreezeInput();
+  }
+
+  handlePreviewClick(event) {
+    const target = event.target.closest('[data-letter-index]');
+    if (!target) {
+      return;
+    }
+
+    const index = Number.parseInt(target.dataset.letterIndex ?? '', 10);
+    if (Number.isNaN(index)) {
+      return;
+    }
+
+    const letter = this.letters[index];
+    if (!letter || !letter.isRevealable) {
+      return;
+    }
+
+    if (this.manualFrozenIndices.has(index)) {
+      this.manualFrozenIndices.delete(index);
+    } else {
+      this.manualFrozenIndices.add(index);
+    }
+
+    this.updateLetterState(letter);
+    this.updateButtonStates();
+  }
+
+  applyText(rawText) {
+    const text = typeof rawText === 'string' ? rawText : '';
+    this.lines = [];
+    this.letters = [];
+    this.autoFrozenIndices.clear();
+    this.manualFrozenIndices.clear();
+    this.revealedByNext.clear();
+    this.nextPointer = 0;
+
+    if (!text.trim()) {
+      this.clearOverlay();
+      this.updateButtonStates();
+      return;
+    }
+
+    const normalised = text.replace(/\r\n/g, '\n');
+    const rawLines = normalised.split('\n');
+    let index = 0;
+
+    rawLines.forEach(line => {
+      const characters = Array.from(line);
+      const lineLetters = characters.map(char => {
+        const letter = this.createLetterData(char, index);
+        this.letters.push(letter);
+        index += 1;
+        return letter;
+      });
+      this.lines.push(lineLetters);
+    });
+
+    this.renderOverlay();
+    this.applyFreezeInput();
+
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(() => this.fitOverlay());
+    } else {
+      this.fitOverlay();
+    }
+  }
+
+  createLetterData(char, index) {
+    const classification = this.classifyCharacter(char);
+    return {
+      index,
+      char,
+      classification,
+      isSpace: classification === 'space',
+      isRevealable: classification !== 'space',
+      element: null,
+      placeholderElement: null,
+      charElement: null,
+      previewElement: null
+    };
+  }
+
+  classifyCharacter(char) {
+    if (!char) {
+      return 'other';
+    }
+
+    if (/\s/.test(char)) {
+      return 'space';
+    }
+
+    if (char === '.') {
+      return 'period';
+    }
+
+    if (/^[0-9]$/.test(char)) {
+      return 'number';
+    }
+
+    if (/^[A-Z]$/.test(char)) {
+      return 'uppercase';
+    }
+
+    if (/^[a-z]$/.test(char)) {
+      return DESCENDER_CHARACTERS.has(char) ? 'descender' : 'lowercase';
+    }
+
+    if (PUNCTUATION_REGEX.test(char)) {
+      return 'punctuation';
+    }
+
+    return 'other';
+  }
+
+  renderOverlay() {
+    if (!this.overlay) {
+      return;
+    }
+
+    this.overlay.innerHTML = '';
+
+    if (!this.letters.length) {
+      this.overlayContent = null;
+      this.setOverlayHidden(true);
+      if (this.previewContainer) {
+        this.previewContainer.innerHTML = '';
+      }
+      return;
+    }
+
+    this.overlayContent = document.createElement('div');
+    this.overlayContent.className = 'teach-content';
+    this.overlay.appendChild(this.overlayContent);
+    this.setOverlayHidden(false);
+
+    if (this.previewContainer) {
+      this.previewContainer.innerHTML = '';
+    }
+
+    this.lines.forEach(line => {
+      const lineElement = document.createElement('div');
+      lineElement.className = 'teach-line';
+      this.overlayContent.appendChild(lineElement);
+
+      let previewLine = null;
+      if (this.previewContainer) {
+        previewLine = document.createElement('div');
+        previewLine.className = 'teach-preview__line';
+        this.previewContainer.appendChild(previewLine);
+      }
+
+      line.forEach(letter => {
+        const letterElement = document.createElement('div');
+        const className = ['teach-letter', this.getLetterClass(letter.classification)];
+        if (letter.isSpace) {
+          className.push('teach-letter--space');
+        }
+        letterElement.className = className.filter(Boolean).join(' ');
+
+        const placeholder = document.createElement('span');
+        placeholder.className = 'teach-placeholder';
+        placeholder.textContent = letter.isSpace ? '\u00a0' : '_';
+
+        const charElement = document.createElement('span');
+        charElement.className = 'teach-char';
+        charElement.textContent = letter.char;
+
+        letterElement.appendChild(placeholder);
+        letterElement.appendChild(charElement);
+        lineElement.appendChild(letterElement);
+
+        letter.element = letterElement;
+        letter.placeholderElement = placeholder;
+        letter.charElement = charElement;
+
+        if (this.previewContainer && previewLine) {
+          if (letter.isSpace) {
+            const space = document.createElement('span');
+            space.className = 'teach-preview__space';
+            space.setAttribute('aria-hidden', 'true');
+            previewLine.appendChild(space);
+          } else {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'teach-preview__letter';
+            button.dataset.letterIndex = String(letter.index);
+            button.textContent = letter.char;
+            button.setAttribute('aria-pressed', 'false');
+            button.setAttribute('aria-label', `Freeze letter ${letter.char}`);
+            button.setAttribute('title', 'Click to freeze or unfreeze this letter');
+            const previewClass = this.getLetterClass(letter.classification);
+            if (previewClass) {
+              button.classList.add(previewClass);
+            }
+            previewLine.appendChild(button);
+            letter.previewElement = button;
+          }
+        }
+      });
+    });
+  }
+
+  clearOverlay() {
+    if (this.overlay) {
+      this.overlay.innerHTML = '';
+      this.setOverlayHidden(true);
+    }
+    if (this.previewContainer) {
+      this.previewContainer.innerHTML = '';
+    }
+    this.overlayContent = null;
+    this.lines = [];
+    this.letters = [];
+    this.autoFrozenIndices.clear();
+    this.manualFrozenIndices.clear();
+    this.revealedByNext.clear();
+    this.nextPointer = 0;
+  }
+
+  applyFreezeInput() {
+    this.autoFrozenIndices.clear();
+
+    if (!this.letters.length) {
+      this.updateAllLetterStates();
+      return;
+    }
+
+    const value = this.freezeInput?.value ?? '';
+    const trimmed = value.replace(/\s+/g, '');
+    if (trimmed) {
+      const characters = Array.from(trimmed.toLowerCase());
+      const freezeSet = new Set(characters);
+      this.letters.forEach(letter => {
+        if (letter.isRevealable && freezeSet.has(letter.char.toLowerCase())) {
+          this.autoFrozenIndices.add(letter.index);
+        }
+      });
+    }
+
+    this.updateAllLetterStates();
+    this.updateButtonStates();
+  }
+
+  revealNextLetter() {
+    if (!this.letters.length) {
+      return;
+    }
+
+    const total = this.letters.length;
+    for (let offset = 0; offset < total; offset += 1) {
+      const index = (this.nextPointer + offset) % total;
+      const letter = this.letters[index];
+      if (!letter || !letter.isRevealable) {
+        continue;
+      }
+      if (this.isLetterRevealed(letter)) {
+        continue;
+      }
+      this.revealedByNext.add(letter.index);
+      this.nextPointer = index + 1;
+      this.updateLetterState(letter);
+      this.updateButtonStates();
+      return;
+    }
+
+    this.updateButtonStates();
+  }
+
+  isLetterFrozen(letterIndex) {
+    return this.autoFrozenIndices.has(letterIndex) || this.manualFrozenIndices.has(letterIndex);
+  }
+
+  isLetterRevealed(letter) {
+    if (!letter) {
+      return false;
+    }
+    if (letter.isSpace) {
+      return true;
+    }
+    if (this.isLetterFrozen(letter.index)) {
+      return true;
+    }
+    return this.revealedByNext.has(letter.index);
+  }
+
+  updateAllLetterStates() {
+    this.letters.forEach(letter => this.updateLetterState(letter));
+  }
+
+  updateLetterState(letter) {
+    if (!letter) {
+      return;
+    }
+
+    const isFrozen = this.isLetterFrozen(letter.index);
+    const isRevealed = this.isLetterRevealed(letter);
+
+    if (letter.element) {
+      letter.element.classList.toggle('is-revealed', isRevealed);
+    }
+
+    if (letter.previewElement) {
+      letter.previewElement.classList.toggle('is-revealed', isRevealed);
+      letter.previewElement.classList.toggle('is-frozen', isFrozen);
+      letter.previewElement.setAttribute('aria-pressed', isFrozen ? 'true' : 'false');
+    }
+  }
+
+  updateButtonStates() {
+    if (!this.nextButton) {
+      return;
+    }
+    const hasRevealableLetters = this.letters.some(letter => letter?.isRevealable);
+    const allRevealed = hasRevealableLetters
+      ? this.letters.every(letter => !letter?.isRevealable || this.isLetterRevealed(letter))
+      : false;
+
+    this.nextButton.disabled = !hasRevealableLetters || allRevealed;
+  }
+
+  fitOverlay() {
+    if (!this.overlay || !this.overlayContent || !this.letters.length) {
+      return;
+    }
+
+    this.overlayContent.style.transform = 'scale(1)';
+
+    const overlayRect = this.overlay.getBoundingClientRect();
+    const contentRect = this.overlayContent.getBoundingClientRect();
+
+    if (!overlayRect.width || !overlayRect.height || !contentRect.width || !contentRect.height) {
+      return;
+    }
+
+    const scaleX = overlayRect.width / contentRect.width;
+    const scaleY = overlayRect.height / contentRect.height;
+    const scale = Math.min(1, scaleX, scaleY);
+    this.overlayContent.style.transform = `scale(${scale})`;
+  }
+
+  setOverlayHidden(isHidden) {
+    if (!this.overlay) {
+      return;
+    }
+    this.overlay.classList.toggle('is-hidden', Boolean(isHidden));
+    this.overlay.setAttribute('aria-hidden', isHidden ? 'true' : 'false');
+  }
+
+  getLetterClass(classification) {
+    switch (classification) {
+      case 'uppercase':
+        return 'teach-letter--uppercase';
+      case 'lowercase':
+        return 'teach-letter--lowercase';
+      case 'descender':
+        return 'teach-letter--descender';
+      case 'period':
+        return 'teach-letter--period';
+      case 'punctuation':
+        return 'teach-letter--punctuation';
+      case 'number':
+        return 'teach-letter--number';
+      case 'other':
+        return 'teach-letter--other';
+      default:
+        return 'teach-letter--default';
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a teaching toolbar with text entry, next button, and freeze input to drive the board overlay
- style the new controls and overlay so underscores scale to fit the board and colour-code characters
- implement a TeachController to render placeholders, handle sequential reveals, and honour frozen letters

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d351f5d7fc8331ac92b6c3fd18f52e