### PR TITLE
Add draggable toolbar and expand rewrite speed range

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -221,17 +221,46 @@ body {
 }
 
 #toolbarBottom {
-  position: relative;
-  width: min(100%, 920px);
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  left: auto;
+  top: auto;
+  width: min(92vw, 920px);
   background: rgba(255, 244, 213, 0.94);
   border-radius: 24px;
   padding: 18px 20px 24px;
   box-shadow: 0 20px 36px rgba(10, 9, 3, 0.18);
   border: 1px solid rgba(10, 9, 3, 0.12);
   backdrop-filter: blur(8px);
-  margin: 6px clamp(16px, 6vw, 48px) 0 auto;
-  align-self: flex-end;
+  margin: 0;
   color: var(--color-smoky-black);
+  z-index: 20;
+}
+
+.toolbar-drag-handle {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding-bottom: 8px;
+  cursor: grab;
+  touch-action: none;
+}
+
+.toolbar-drag-handle:active {
+  cursor: grabbing;
+}
+
+.toolbar-drag-grip {
+  width: 64px;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(10, 9, 3, 0.28);
+  box-shadow: 0 2px 6px rgba(10, 9, 3, 0.15);
+}
+
+#toolbarBottom.is-dragging .toolbar-drag-grip {
+  background: rgba(10, 9, 3, 0.45);
 }
 
 .toolbar-inner {
@@ -699,6 +728,10 @@ body {
 @media (max-width: 640px) {
   #toolbarBottom {
     padding: 18px 16px 26px;
+    right: 12px;
+    left: 12px;
+    bottom: 12px;
+    width: auto;
   }
 
   .toolbar-group.toolbar-left,

--- a/index.html
+++ b/index.html
@@ -85,6 +85,15 @@
       </div>
 
       <div id="toolbarBottom" role="toolbar" aria-label="Handwriting controls" class="disable-select">
+        <div
+          class="toolbar-drag-handle"
+          id="toolbarDragHandle"
+          role="presentation"
+          aria-hidden="true"
+          title="Drag toolbar"
+        >
+          <span class="toolbar-drag-grip" aria-hidden="true"></span>
+        </div>
         <div class="toolbar-inner">
           <div class="toolbar-group toolbar-left" role="group" aria-label="Zoom and speed">
             <button class="btn icon" id="btnZoomOut" type="button" aria-label="Zoom out" title="Zoom out">
@@ -103,11 +112,11 @@
                 class="slider"
                 type="range"
                 min="0.5"
-                max="4"
+                max="8"
                 step="0.1"
                 value="2"
                 aria-valuemin="0.5"
-                aria-valuemax="4"
+                aria-valuemax="8"
                 aria-valuenow="2"
                 aria-label="Rewrite speed"
               />


### PR DESCRIPTION
## Summary
- make the control toolbar draggable with a grab handle and persist its position between sessions
- update the toolbar styling for fixed placement and add responsive tweaks for the draggable handle
- extend the rewrite speed slider and logic so playback can run up to 8× faster

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d353c6cca483318e5cb3514cda2193