### PR TITLE
Add lesson title controls and refine board display

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -84,6 +84,50 @@ body {
   color: var(--color-smoky-black);
 }
 
+.lesson-controls {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 0 16px 16px;
+}
+
+.lesson-title-field {
+  width: min(100%, 380px);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: var(--color-smoky-black);
+}
+
+.lesson-title-label {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.95rem;
+}
+
+.lesson-title-input {
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 2px solid rgba(10, 9, 3, 0.16);
+  background: rgba(255, 244, 213, 0.92);
+  font-size: 1.05rem;
+  font-family: inherit;
+  color: var(--color-smoky-black);
+  box-shadow: 0 10px 22px rgba(10, 9, 3, 0.18);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.lesson-title-input:focus {
+  outline: none;
+  border-color: rgba(255, 130, 0, 0.7);
+  box-shadow: 0 14px 28px rgba(10, 9, 3, 0.22);
+}
+
+.lesson-title-input::placeholder {
+  color: rgba(10, 9, 3, 0.55);
+}
+
 .main-container {
   width: 100%;
   display: flex;
@@ -133,17 +177,26 @@ body {
   pointer-events: auto;
 }
 
-#boardDate {
+.board-header {
   position: absolute;
   top: 16px;
   right: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 10px;
+  pointer-events: none;
+}
+
+#boardDate {
+  pointer-events: auto;
   color: var(--color-smoky-black);
   font-family: 'KG Primary', 'Comic Sans MS', 'Comic Sans', cursive;
-  font-size: clamp(1.75rem, 2vw + 1.25rem, 3rem);
+  font-size: clamp(1.4rem, 1.6vw + 1.1rem, 2.5rem);
   text-shadow: 0.08em 0.08em rgba(255, 201, 41, 0.3);
   font-weight: 700;
   letter-spacing: 0.05em;
-  padding: 12px 18px;
+  padding: 10px 16px;
   background: rgba(255, 244, 213, 0.9);
   border-radius: 14px;
   border: 2px solid rgba(10, 9, 3, 0.12);
@@ -151,6 +204,25 @@ body {
   cursor: pointer;
   user-select: none;
   transition: transform 0.15s ease;
+}
+
+.board-lesson-title {
+  pointer-events: none;
+  color: var(--color-smoky-black);
+  font-family: 'KG Primary', 'Comic Sans MS', 'Comic Sans', cursive;
+  font-size: clamp(2rem, 2vw + 1.35rem, 3.2rem);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-shadow: 0.08em 0.08em rgba(255, 201, 41, 0.26);
+  padding: 4px 12px 6px;
+  min-height: 1.3em;
+  min-width: clamp(220px, 22vw, 340px);
+  text-align: right;
+  transition: opacity 0.2s ease;
+}
+
+.board-lesson-title.is-hidden {
+  opacity: 0;
 }
 
 #boardDate:hover,
@@ -484,6 +556,9 @@ body.is-fullscreen #toolbarBottom.is-collapsed .toolbar-toggle__icon {
   border-radius: 999px;
   background: rgba(10, 9, 3, 0.12);
   overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
 }
 
 #timerProgress::after {
@@ -493,6 +568,10 @@ body.is-fullscreen #toolbarBottom.is-collapsed .toolbar-toggle__icon {
   width: var(--progress, 0%);
   background: linear-gradient(90deg, var(--color-sunglow) 0%, var(--color-ut-orange) 100%);
   transition: width 0.2s linear;
+}
+
+#timerProgress.is-visible {
+  opacity: 1;
 }
 
 .popover {

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Handwriting Repeater</title>
+    <title>Master handwriting</title>
     <meta
       name="description"
       content="Handwriting Repeater is an interactive handwriting practice tool with looping playback, tracing guides, and adjustable pen settings to help learners master letter formation."
@@ -61,9 +61,22 @@
   <body>
     <header class="title-container" role="banner">
       <div class="title-texts">
-        <h1 class="title-text">Handwriting Repeater</h1>
+        <h1 class="title-text">Master handwriting</h1>
       </div>
     </header>
+
+    <section class="lesson-controls" aria-label="Lesson details">
+      <div class="lesson-title-field">
+        <label class="lesson-title-label" for="inputLessonTitle">Lesson title</label>
+        <input
+          type="text"
+          id="inputLessonTitle"
+          class="lesson-title-input"
+          placeholder="Lesson title here"
+          autocomplete="off"
+        />
+      </div>
+    </section>
 
     <main class="main-container disable-select" role="main">
       <div id="writerContainer" class="writer-container">
@@ -75,7 +88,15 @@
           <canvas id="writerMask" width="1200" height="600"></canvas>
         </div>
 
-        <div id="boardDate" aria-label="Date" role="button" tabindex="0">Loading date…</div>
+        <div id="boardHeader" class="board-header">
+          <div id="boardDate" aria-label="Date" role="button" tabindex="0">Loading date…</div>
+          <div
+            id="boardLessonTitle"
+            class="board-lesson-title is-hidden"
+            aria-live="polite"
+            aria-hidden="true"
+          ></div>
+        </div>
         <div id="retroTv" class="tv-off" aria-hidden="true">
           <div class="tv-frame">
             <div id="tvPlayer" class="tv-screen" title="Retro TV" role="presentation"></div>

--- a/js/Controls.js
+++ b/js/Controls.js
@@ -96,6 +96,8 @@ export class Controls {
     this.cookieSettingsLink = document.getElementById('cookieSettingsLink');
 
     this.boardDate = document.getElementById('boardDate');
+    this.boardLessonTitle = document.getElementById('boardLessonTitle');
+    this.lessonTitleInput = document.getElementById('inputLessonTitle');
 
     this.openPopover = null;
     this.openPopoverButton = null;
@@ -111,6 +113,7 @@ export class Controls {
     this.setupAuxiliaryButtons();
     this.setupCookieBanner();
     this.setupDateDisplay();
+    this.setupLessonTitle();
     this.setupFullscreenBehaviour();
     this.applyToolbarLayoutVersion();
     this.applyInitialState();
@@ -494,7 +497,12 @@ export class Controls {
     }
 
     if (storedDate) {
-      this.boardDate.textContent = storedDate;
+      const needsUpdate = /\d(?:st|nd|rd|th)/.test(storedDate) || !storedDate.includes(',');
+      if (needsUpdate) {
+        applyDate();
+      } else {
+        this.boardDate.textContent = storedDate;
+      }
     } else {
       applyDate();
     }
@@ -509,6 +517,51 @@ export class Controls {
         applyDate();
       }
     });
+  }
+
+  setupLessonTitle() {
+    if (!this.lessonTitleInput || !this.boardLessonTitle) {
+      return;
+    }
+
+    let storedTitle = '';
+    if (typeof window !== 'undefined' && window.localStorage) {
+      storedTitle = window.localStorage.getItem('ui.lessonTitle') ?? '';
+    }
+
+    const initialTitle = storedTitle.trim();
+    this.lessonTitleInput.value = storedTitle;
+    this.applyLessonTitle(initialTitle);
+
+    this.lessonTitleInput.addEventListener('input', event => {
+      const rawValue = event.target.value ?? '';
+      const trimmedValue = rawValue.trim();
+      this.applyLessonTitle(trimmedValue);
+
+      if (typeof window !== 'undefined' && window.localStorage) {
+        if (trimmedValue) {
+          window.localStorage.setItem('ui.lessonTitle', trimmedValue);
+        } else {
+          window.localStorage.removeItem('ui.lessonTitle');
+        }
+      }
+    });
+  }
+
+  applyLessonTitle(title) {
+    if (!this.boardLessonTitle) {
+      return;
+    }
+
+    if (title) {
+      this.boardLessonTitle.textContent = title;
+      this.boardLessonTitle.classList.remove('is-hidden');
+      this.boardLessonTitle.setAttribute('aria-hidden', 'false');
+    } else {
+      this.boardLessonTitle.textContent = '';
+      this.boardLessonTitle.classList.add('is-hidden');
+      this.boardLessonTitle.setAttribute('aria-hidden', 'true');
+    }
   }
 
   applyToolbarLayoutVersion() {
@@ -727,6 +780,9 @@ export class Controls {
     if (this.timerButton) {
       this.timerButton.classList.toggle('is-active', isActive);
       this.timerButton.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    }
+    if (this.timerProgress) {
+      this.timerProgress.classList.toggle('is-visible', isActive);
     }
   }
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -31,17 +31,13 @@ export function clamp(value, min, max) {
   return Math.min(Math.max(value, min), max);
 }
 
-const ORDINAL_SUFFIXES = { 1: 'st', 2: 'nd', 3: 'rd' };
-
 export function formatDateWithOrdinal(date = new Date()) {
-  const day = date.getDate();
-  const suffix = ORDINAL_SUFFIXES[day % 10] && ![11, 12, 13].includes(day) ? ORDINAL_SUFFIXES[day % 10] : 'th';
-  const formatter = new Intl.DateTimeFormat('en-GB', {
-    weekday: 'long',
+  const safeDate = date instanceof Date ? date : new Date(date);
+  const weekday = new Intl.DateTimeFormat('en-GB', { weekday: 'long' }).format(safeDate);
+  const dayMonthYear = new Intl.DateTimeFormat('en-GB', {
     day: 'numeric',
     month: 'long',
     year: 'numeric'
-  });
-  const formatted = formatter.format(date);
-  return formatted.replace(String(day), `${day}${suffix}`);
+  }).format(safeDate);
+  return `${weekday}, ${dayMonthYear}`;
 }


### PR DESCRIPTION
## Summary
- rename the app heading to “Master handwriting” and add a lesson title input for teachers
- show an optional lesson title on the board beneath the smaller date and persist it locally
- hide the timer progress bar until the timer runs and standardise the stored date format with a comma

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d3555217208331be7ec2150efbdbc6