### PR TITLE
Clear practice text input after teaching

### DIFF
--- a/js/teach.js
+++ b/js/teach.js
@@ -55,6 +55,10 @@ export class TeachController {
   handleTeach() {
     const text = this.textInput?.value ?? '';
     this.applyText(text);
+
+    if (this.textInput) {
+      this.textInput.value = '';
+    }
   }
 
   handleNext() {


### PR DESCRIPTION
## Summary
- clear the practice text input once the Teach action runs so students can’t read the typed prompt

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d35a75f08c833188ade7271833fa2c