### PR TITLE
Remove freeze letters input and reorganize teach preview

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -274,11 +274,19 @@ body {
   gap: 6px;
 }
 
+.teach-preview-block {
+  gap: 8px;
+}
+
 .teach-label {
   font-size: 0.95rem;
   font-weight: 600;
   letter-spacing: 0.02em;
   color: var(--color-smoky-black);
+}
+
+.teach-preview__title {
+  margin: 0;
 }
 
 .teach-input-row {

--- a/index.html
+++ b/index.html
@@ -150,17 +150,10 @@
                 </button>
               </div>
             </div>
-            <div class="teach-field">
-              <label class="teach-label" for="freezeLettersInput">Freeze letters</label>
-              <input
-                id="freezeLettersInput"
-                class="teach-input"
-                type="text"
-                placeholder="Enter letters to keep visible"
-                autocomplete="off"
-              />
+            <div class="teach-field teach-preview-block">
+              <p class="teach-label teach-preview__title">Freeze letters</p>
+              <div class="teach-preview" id="teachPreview" aria-label="Sentence letter controls"></div>
             </div>
-            <div class="teach-preview" id="teachPreview" aria-label="Sentence letter controls"></div>
           </div>
 
           <div class="toolbar-group toolbar-right" role="group" aria-label="Drawing controls">

--- a/js/main.js
+++ b/js/main.js
@@ -53,7 +53,6 @@ new TeachController({
   textInput: document.getElementById('teachTextInput'),
   teachButton: document.getElementById('btnTeach'),
   nextButton: document.getElementById('btnTeachNext'),
-  freezeInput: document.getElementById('freezeLettersInput'),
   previewContainer: document.getElementById('teachPreview')
 });
 


### PR DESCRIPTION
## Summary
- remove the freeze letters text field from the toolbar and introduce a labelled preview block instead
- simplify the teach controller by dropping freeze-input handling while keeping manual freeze toggles
- adjust styling so the freeze letter controls sit below the teach buttons with consistent spacing

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d35a0c06548331a009e53135b6b01f