### PR TITLE
Improve board zoom responsiveness and freeze letters controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -195,22 +195,31 @@ body {
   touch-action: none;
   background: rgba(255, 244, 213, 0.72);
   border-radius: 24px;
-  padding: 20px;
+  padding: clamp(16px, 2.5vw, 24px);
   box-shadow: 0 18px 36px rgba(10, 9, 3, 0.22);
   overflow: hidden;
   --zoom-level: 1;
+  --board-width: 1200px;
+  width: min(100%, calc(var(--board-width, 1200px) + 48px));
+  max-width: calc(var(--board-width, 1200px) + 48px);
 }
 
 .writer-board {
+  position: relative;
   display: grid;
   grid-template-columns: 1fr;
-  justify-items: center;
-  align-items: center;
+  justify-items: stretch;
+  align-items: stretch;
+  min-width: 0;
+  width: min(100%, var(--board-width, 1200px));
+  aspect-ratio: 2 / 1;
 }
 
 .writer-board canvas {
   grid-row: 1;
   grid-column: 1;
+  width: 100%;
+  height: 100%;
 }
 
 #writerPage,
@@ -510,19 +519,56 @@ body {
   line-height: 1;
 }
 
+.teach-preview__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+}
+
+.teach-preview__toggle {
+  padding: 6px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(10, 9, 3, 0.18);
+  background: rgba(255, 255, 255, 0.85);
+  font-family: inherit;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--color-smoky-black);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.12s ease, transform 0.12s ease;
+}
+
+.teach-preview__toggle:hover,
+.teach-preview__toggle:focus-visible {
+  outline: none;
+  transform: translateY(-1px);
+  box-shadow: 0 6px 14px rgba(10, 9, 3, 0.16);
+}
+
+.teach-preview__toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  background: rgba(255, 255, 255, 0.7);
+  color: rgba(10, 9, 3, 0.65);
+  transform: none;
+  box-shadow: none;
+}
+
 .teach-preview {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   gap: 6px;
   align-items: flex-start;
+  justify-content: flex-start;
+  width: 100%;
   pointer-events: auto;
   user-select: none;
 }
 
-.teach-preview__line {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
+.teach-preview.is-hidden {
+  display: none;
 }
 
 .teach-preview__letter {
@@ -578,7 +624,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: clamp(18px, 4vw, 48px);
+  padding: clamp(28px, 6vw, 72px) clamp(36px, 8vw, 140px);
   pointer-events: none;
   z-index: 2;
 }
@@ -1228,9 +1274,6 @@ body.is-fullscreen #toolbarBottom.is-collapsed .toolbar-toggle__icon {
 
   .teach-preview {
     align-items: stretch;
-  }
-
-  .teach-preview__line {
     justify-content: center;
   }
 

--- a/index.html
+++ b/index.html
@@ -192,7 +192,18 @@
               </div>
             </div>
             <div class="teach-field teach-preview-block">
-              <p class="teach-label teach-preview__title">Freeze letters</p>
+              <div class="teach-preview__header">
+                <p class="teach-label teach-preview__title">Freeze letters</p>
+                <button
+                  type="button"
+                  id="btnToggleFreezePreview"
+                  class="teach-preview__toggle"
+                  aria-controls="teachPreview"
+                  aria-expanded="true"
+                >
+                  Hide letters
+                </button>
+              </div>
               <div class="teach-preview" id="teachPreview" aria-label="Sentence letter controls"></div>
             </div>
           </div>

--- a/js/Controls.js
+++ b/js/Controls.js
@@ -208,8 +208,8 @@ export class Controls {
       if (!canvas) return;
       canvas.width = CANVAS_WIDTH;
       canvas.height = CANVAS_HEIGHT;
-      canvas.style.width = `${CANVAS_WIDTH}px`;
-      canvas.style.height = `${CANVAS_HEIGHT}px`;
+      canvas.style.width = '100%';
+      canvas.style.height = '100%';
     });
   }
 
@@ -833,10 +833,16 @@ export class Controls {
   setZoom(value, persist = true) {
     const zoom = clamp(Number(value) || DEFAULT_SETTINGS.zoomLevel, 0.5, 3);
     this.userData.userSettings.zoomLevel = zoom;
+    const boardWidth = CANVAS_WIDTH * zoom;
     if (this.writerContainer) {
-      this.writerContainer.style.transform = `scale(${zoom})`;
-      this.writerContainer.style.transformOrigin = 'top center';
+      this.writerContainer.style.transform = '';
+      this.writerContainer.style.transformOrigin = '';
       this.writerContainer.style.setProperty('--zoom-level', String(zoom));
+      this.writerContainer.style.setProperty('--board-width', `${boardWidth}px`);
+    }
+
+    if (this.writerBoard) {
+      this.writerBoard.style.setProperty('--board-width', `${boardWidth}px`);
     }
 
     if (persist) {

--- a/js/main.js
+++ b/js/main.js
@@ -54,7 +54,8 @@ new TeachController({
   textInput: document.getElementById('teachTextInput'),
   teachButton: document.getElementById('btnTeach'),
   nextButton: document.getElementById('btnTeachNext'),
-  previewContainer: document.getElementById('teachPreview')
+  previewContainer: document.getElementById('teachPreview'),
+  previewToggleButton: document.getElementById('btnToggleFreezePreview')
 });
 
 async function loadInitialPenImage() {


### PR DESCRIPTION
## Summary
- adjust the board zoom implementation so only the writing surface scales and remains responsive to viewport size
- add additional spacing and responsive sizing to the teach overlay and canvases for better usability at different window scales
- update freeze letters preview to sort characters alphabetically, add a hide/show toggle, and refresh related styles and accessibility labels

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d36bafc8e48331b910830a5dc6f88c