### PR TITLE
Refine board layout controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -193,15 +193,17 @@ body {
   justify-items: center;
   align-items: center;
   touch-action: none;
-  background: rgba(255, 244, 213, 0.72);
-  border-radius: 24px;
-  padding: clamp(16px, 2.5vw, 24px);
-  box-shadow: 0 18px 36px rgba(10, 9, 3, 0.22);
-  overflow: hidden;
+  background: linear-gradient(180deg, rgba(255, 201, 41, 0.28) 0%, rgba(255, 244, 213, 0.96) 100%);
+  border-radius: 28px;
+  border: 6px solid rgba(255, 130, 0, 0.85);
+  padding: clamp(20px, 3vw, 28px);
+  padding-bottom: clamp(96px, 12vw, 140px);
+  box-shadow: 0 26px 48px rgba(10, 9, 3, 0.28);
+  overflow: visible;
   --zoom-level: 1;
   --board-width: 1200px;
-  width: min(100%, calc(var(--board-width, 1200px) + 48px));
-  max-width: calc(var(--board-width, 1200px) + 48px);
+  width: min(100%, calc(var(--board-width, 1200px) + 88px));
+  max-width: calc(var(--board-width, 1200px) + 88px);
 }
 
 .writer-board {
@@ -213,6 +215,11 @@ body {
   min-width: 0;
   width: min(100%, var(--board-width, 1200px));
   aspect-ratio: 2 / 1;
+  border-radius: 24px;
+  border: 5px solid rgba(255, 130, 0, 0.8);
+  background: #ffffff;
+  box-shadow: 0 22px 44px rgba(10, 9, 3, 0.24);
+  overflow: hidden;
 }
 
 .writer-board canvas {
@@ -220,6 +227,137 @@ body {
   grid-column: 1;
   width: 100%;
   height: 100%;
+}
+
+.board-side-controls {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 30;
+  pointer-events: none;
+}
+
+.board-side-controls__panel {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  background: rgba(255, 244, 213, 0.96);
+  border: 3px solid rgba(255, 130, 0, 0.85);
+  border-radius: 22px;
+  box-shadow: 0 16px 32px rgba(10, 9, 3, 0.26);
+  pointer-events: auto;
+}
+
+.board-side-controls__panel::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: -10px;
+  transform: translateY(-50%);
+  width: 18px;
+  height: 48px;
+  background: inherit;
+  border: inherit;
+  border-left: none;
+  border-radius: 0 18px 18px 0;
+  box-shadow: none;
+  z-index: -1;
+}
+
+.board-side-controls--left {
+  left: 0;
+  transform: translate(calc(-100% + 18px), -50%);
+}
+
+.board-bookmarks {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: 0;
+  z-index: 30;
+}
+
+.board-bookmarks__panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px 18px 16px 20px;
+  background: rgba(255, 244, 213, 0.96);
+  border: 3px solid rgba(255, 130, 0, 0.85);
+  border-right: none;
+  border-radius: 22px 0 0 22px;
+  box-shadow: 0 16px 32px rgba(10, 9, 3, 0.26);
+  transform: translateX(100%);
+  opacity: 0;
+  pointer-events: none;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.board-bookmarks__panel::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: -10px;
+  transform: translateY(-50%);
+  width: 18px;
+  height: 48px;
+  background: inherit;
+  border: 3px solid rgba(255, 130, 0, 0.85);
+  border-right: none;
+  border-radius: 18px 0 0 18px;
+  box-shadow: none;
+  z-index: -1;
+}
+
+.board-bookmarks.is-expanded .board-bookmarks__panel {
+  transform: translateX(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.board-bookmarks__toggle {
+  width: 56px;
+  height: 60px;
+  border-radius: 0 24px 24px 0;
+  border: 3px solid rgba(255, 130, 0, 0.9);
+  border-left: none;
+  background: linear-gradient(180deg, rgba(255, 130, 0, 0.98) 0%, rgba(255, 201, 41, 0.98) 100%);
+  color: var(--color-smoky-black);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 18px 34px rgba(10, 9, 3, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.board-bookmarks__toggle:hover,
+.board-bookmarks__toggle:focus-visible {
+  outline: none;
+  transform: translateX(-2px);
+  box-shadow: 0 22px 42px rgba(10, 9, 3, 0.36);
+}
+
+.board-bookmarks__toggle:active {
+  transform: translateX(0);
+  box-shadow: 0 12px 24px rgba(10, 9, 3, 0.26);
+}
+
+.board-bookmarks__toggle-icon {
+  width: 22px;
+  height: 22px;
+  fill: currentColor;
+  transform: rotate(-90deg);
+  transition: transform 0.3s ease;
+}
+
+.board-bookmarks.is-expanded .board-bookmarks__toggle-icon {
+  transform: rotate(90deg);
 }
 
 #writerPage,
@@ -940,9 +1078,9 @@ body.is-fullscreen #toolbarBottom.is-collapsed .toolbar-toggle__icon {
 
 #timerProgress {
   position: absolute;
-  left: 24px;
-  right: 24px;
-  bottom: 12px;
+  left: clamp(28px, 4vw, 44px);
+  right: clamp(28px, 4vw, 44px);
+  bottom: clamp(18px, 2.6vw, 36px);
   height: 4px;
   border-radius: 999px;
   background: rgba(10, 9, 3, 0.12);
@@ -1187,7 +1325,8 @@ body.is-fullscreen #toolbarBottom.is-collapsed .toolbar-toggle__icon {
 
 @media (max-width: 900px) {
   .writer-container {
-    padding: 16px;
+    padding: 18px;
+    padding-bottom: clamp(120px, 32vw, 200px);
   }
 
   .toolbar-inner {
@@ -1206,6 +1345,25 @@ body.is-fullscreen #toolbarBottom.is-collapsed .toolbar-toggle__icon {
   .btn-primary {
     width: 64px;
     height: 64px;
+  }
+
+  .board-side-controls--left {
+    left: 12px;
+    transform: translate(0, -50%);
+  }
+
+  .board-side-controls__panel::after,
+  .board-bookmarks__panel::before {
+    display: none;
+  }
+
+  .board-bookmarks {
+    right: 12px;
+  }
+
+  .board-bookmarks__toggle {
+    width: 48px;
+    height: 52px;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -90,6 +90,70 @@
 
     <main class="main-container disable-select" role="main">
       <div id="writerContainer" class="writer-container">
+        <div class="board-side-controls board-side-controls--left" role="group" aria-label="Board controls">
+          <div class="board-side-controls__panel">
+            <button class="btn icon" id="btnUndo" type="button" aria-label="Undo" title="Undo">
+              <svg aria-hidden="true"><use href="assets/icons.svg#undo"></use></svg>
+            </button>
+            <button class="btn icon" id="btnRedo" type="button" aria-label="Redo" title="Redo">
+              <svg aria-hidden="true"><use href="assets/icons.svg#redo"></use></svg>
+            </button>
+            <button class="btn icon" id="btnReset" type="button" aria-label="Reset" title="Reset">
+              <svg aria-hidden="true"><use href="assets/icons.svg#reset"></use></svg>
+            </button>
+            <button
+              class="btn icon"
+              id="btnPageStyle"
+              type="button"
+              aria-label="Page style"
+              title="Page style"
+              aria-haspopup="dialog"
+              aria-expanded="false"
+            >
+              <svg aria-hidden="true"><use href="assets/icons.svg#page-lines"></use></svg>
+            </button>
+          </div>
+        </div>
+
+        <div class="board-bookmarks" id="boardBookmarks">
+          <div class="board-bookmarks__panel" id="boardBookmarksPanel" role="group" aria-label="Quick actions" aria-hidden="true">
+            <button
+              class="btn icon"
+              id="btnTimer"
+              type="button"
+              aria-label="Timer"
+              title="Timer"
+              aria-haspopup="dialog"
+              aria-expanded="false"
+              aria-pressed="false"
+              tabindex="-1"
+            >
+              <svg aria-hidden="true"><use href="assets/icons.svg#timer"></use></svg>
+            </button>
+            <button class="btn icon" id="btnUploadPen" type="button" aria-label="Upload pen image" title="Upload pen image" tabindex="-1">
+              <svg aria-hidden="true"><use href="assets/icons.svg#upload"></use></svg>
+            </button>
+            <button class="btn icon is-disabled" id="btnRemovePenImage" type="button" aria-label="Remove custom pen image" title="Remove custom pen image" disabled tabindex="-1">
+              <svg aria-hidden="true"><use href="assets/icons.svg#close"></use></svg>
+            </button>
+            <button class="btn icon" id="btnFullscreen" type="button" aria-label="Fullscreen" title="Fullscreen" tabindex="-1">
+              <svg aria-hidden="true"><use href="assets/icons.svg#fullscreen"></use></svg>
+            </button>
+          </div>
+          <button
+            type="button"
+            class="board-bookmarks__toggle"
+            id="boardBookmarksToggle"
+            aria-controls="boardBookmarksPanel"
+            aria-expanded="false"
+            aria-label="Show quick actions"
+          >
+            <svg class="board-bookmarks__toggle-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M12 16.5 5.5 10l1.41-1.41L12 13.67l5.09-5.08L18.5 10z"></path>
+            </svg>
+          </button>
+        </div>
+
         <div id="writerBoard" class="writer-board">
           <canvas id="writerPage" width="1200" height="600"></canvas>
           <canvas id="writerTrace" width="1200" height="600"></canvas>
@@ -114,6 +178,8 @@
             <div class="tv-overlay" aria-hidden="true"></div>
           </div>
         </div>
+
+        <div id="timerProgress" aria-hidden="true"></div>
       </div>
 
       <div id="toolbarBottom" role="toolbar" aria-label="Handwriting controls" class="disable-select">
@@ -208,27 +274,7 @@
             </div>
           </div>
 
-          <div class="toolbar-group toolbar-right" role="group" aria-label="Drawing controls">
-            <button class="btn icon" id="btnUndo" type="button" aria-label="Undo" title="Undo">
-              <svg aria-hidden="true"><use href="assets/icons.svg#undo"></use></svg>
-            </button>
-            <button class="btn icon" id="btnRedo" type="button" aria-label="Redo" title="Redo">
-              <svg aria-hidden="true"><use href="assets/icons.svg#redo"></use></svg>
-            </button>
-            <button class="btn icon" id="btnReset" type="button" aria-label="Reset" title="Reset">
-              <svg aria-hidden="true"><use href="assets/icons.svg#reset"></use></svg>
-            </button>
-            <button
-              class="btn icon"
-              id="btnPageStyle"
-              type="button"
-              aria-label="Page style"
-              title="Page style"
-              aria-haspopup="dialog"
-              aria-expanded="false"
-            >
-              <svg aria-hidden="true"><use href="assets/icons.svg#page-lines"></use></svg>
-            </button>
+          <div class="toolbar-group toolbar-right" role="group" aria-label="Pen controls">
             <div class="slider-control" id="penSizeControl">
               <span class="icon-leading" aria-hidden="true">
                 <svg><use href="assets/icons.svg#pen"></use></svg>
@@ -259,37 +305,8 @@
             >
               <svg aria-hidden="true"><use href="assets/icons.svg#palette"></use></svg>
             </button>
-            <button class="btn icon" id="btnUploadPen" type="button" aria-label="Upload pen image" title="Upload pen image">
-              <svg aria-hidden="true"><use href="assets/icons.svg#upload"></use></svg>
-            </button>
-            <button
-              class="btn icon is-disabled"
-              id="btnRemovePenImage"
-              type="button"
-              aria-label="Remove custom pen image"
-              title="Remove custom pen image"
-              disabled
-            >
-              <svg aria-hidden="true"><use href="assets/icons.svg#close"></use></svg>
-            </button>
-            <button
-              class="btn icon"
-              id="btnTimer"
-              type="button"
-              aria-label="Timer"
-              title="Timer"
-              aria-haspopup="dialog"
-              aria-expanded="false"
-              aria-pressed="false"
-            >
-              <svg aria-hidden="true"><use href="assets/icons.svg#timer"></use></svg>
-            </button>
-            <button class="btn icon" id="btnFullscreen" type="button" aria-label="Fullscreen" title="Fullscreen">
-              <svg aria-hidden="true"><use href="assets/icons.svg#fullscreen"></use></svg>
-            </button>
           </div>
         </div>
-        <div id="timerProgress" aria-hidden="true"></div>
       </div>
     </main>
 

--- a/js/Controls.js
+++ b/js/Controls.js
@@ -89,6 +89,10 @@ export class Controls {
       : [];
     this.timerProgress = document.getElementById('timerProgress');
 
+    this.boardBookmarks = document.getElementById('boardBookmarks');
+    this.boardBookmarksToggle = document.getElementById('boardBookmarksToggle');
+    this.boardBookmarksPanel = document.getElementById('boardBookmarksPanel');
+
     this.toolbarBottom = document.getElementById('toolbarBottom');
     this.toolbarToggleButton = document.getElementById('toolbarToggle');
     this.toolbarOriginalParent = this.toolbarBottom?.parentElement ?? null;
@@ -123,6 +127,7 @@ export class Controls {
     this.setupSliders();
     this.setupZoomButtons();
     this.setupAuxiliaryButtons();
+    this.setupBookmarkDock();
     this.setupToolbarDragging();
     this.setupCookieBanner();
     this.setupDateDisplay();
@@ -428,6 +433,64 @@ export class Controls {
           document.exitFullscreen();
         } else {
           (this.writerContainer ?? document.documentElement).requestFullscreen().catch(() => {});
+        }
+      });
+    }
+  }
+
+  setupBookmarkDock() {
+    if (!this.boardBookmarks || !this.boardBookmarksToggle) {
+      return;
+    }
+
+    const panel = this.boardBookmarksPanel ?? null;
+    const actionButtons = panel ? Array.from(panel.querySelectorAll('button')) : [];
+
+    const setExpandedState = expanded => {
+      this.boardBookmarks.classList.toggle('is-expanded', expanded);
+      this.boardBookmarksToggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+      this.boardBookmarksToggle.setAttribute('aria-label', expanded ? 'Hide quick actions' : 'Show quick actions');
+      if (panel) {
+        panel.setAttribute('aria-hidden', expanded ? 'false' : 'true');
+      }
+      actionButtons.forEach(button => {
+        if (expanded) {
+          button.removeAttribute('tabindex');
+        } else {
+          button.setAttribute('tabindex', '-1');
+        }
+      });
+      if (!expanded && this.openPopoverButton && actionButtons.includes(this.openPopoverButton)) {
+        this.closeOpenPopover();
+      }
+    };
+
+    setExpandedState(false);
+
+    this.boardBookmarksToggle.addEventListener('click', () => {
+      const isExpanded = this.boardBookmarks.classList.contains('is-expanded');
+      const nextExpanded = !isExpanded;
+      setExpandedState(nextExpanded);
+      if (nextExpanded && actionButtons.length > 0) {
+        window.setTimeout(() => {
+          const firstButton = actionButtons[0];
+          if (firstButton && typeof firstButton.focus === 'function') {
+            try {
+              firstButton.focus({ preventScroll: true });
+            } catch (error) {
+              firstButton.focus();
+            }
+          }
+        }, 0);
+      }
+    });
+
+    if (panel) {
+      panel.addEventListener('keydown', event => {
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          setExpandedState(false);
+          this.boardBookmarksToggle.focus({ preventScroll: true });
         }
       });
     }


### PR DESCRIPTION
## Summary
- keep the board’s orange frame visible by refreshing the writer container and board styling
- relocate undo/reset/background controls to the board edge and add a bookmark-style quick actions dock for timer, pen upload and fullscreen
- extend the controls script to drive the new dock and preserve focus/aria behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d372a0d668833199aa83419cc55772