### PR TITLE
Add feedback email form to site footer

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1396,6 +1396,124 @@ body.is-fullscreen #toolbarBottom.is-collapsed .toolbar-toggle__icon {
   margin: 0;
 }
 
+.feedback-section {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: clamp(36px, 8vw, 72px) 16px clamp(48px, 10vw, 96px);
+  background: rgba(10, 9, 3, 0.08);
+}
+
+.feedback-section__inner {
+  width: min(100%, 520px);
+  background: rgba(255, 244, 213, 0.96);
+  color: var(--color-smoky-black);
+  border-radius: 24px;
+  padding: clamp(24px, 6vw, 40px);
+  box-shadow: 0 18px 38px rgba(10, 9, 3, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 4vw, 24px);
+}
+
+.feedback-section h2 {
+  margin: 0;
+  font-family: "Comic Sans MS", "KG Primary", "Chalkboard SE", "Comic Neue", cursive;
+  font-size: clamp(1.6rem, 3.8vw, 2.4rem);
+  color: var(--color-ut-orange);
+  text-align: center;
+}
+
+.feedback-description {
+  margin: 0;
+  font-size: clamp(1rem, 2.2vw, 1.1rem);
+  line-height: 1.6;
+  text-align: center;
+}
+
+.feedback-form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.feedback-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.feedback-label {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.9rem;
+}
+
+.feedback-input,
+.feedback-textarea {
+  width: 100%;
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 2px solid rgba(10, 9, 3, 0.16);
+  background: rgba(255, 255, 255, 0.92);
+  font-family: inherit;
+  font-size: 1rem;
+  color: var(--color-smoky-black);
+  box-shadow: 0 12px 26px rgba(10, 9, 3, 0.16);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.feedback-input:focus,
+.feedback-textarea:focus {
+  outline: none;
+  border-color: rgba(255, 130, 0, 0.7);
+  box-shadow: 0 16px 32px rgba(10, 9, 3, 0.2);
+}
+
+.feedback-textarea {
+  min-height: 140px;
+  resize: vertical;
+}
+
+.feedback-submit {
+  align-self: center;
+  padding: 14px 32px;
+  border-radius: 999px;
+  border: 2px solid rgba(10, 9, 3, 0.16);
+  background: linear-gradient(180deg, rgba(255, 130, 0, 0.96) 0%, rgba(255, 201, 41, 0.96) 100%);
+  color: var(--color-smoky-black);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 1rem;
+  box-shadow: 0 12px 26px rgba(10, 9, 3, 0.18);
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
+}
+
+.feedback-submit:hover,
+.feedback-submit:focus-visible {
+  box-shadow: 0 16px 32px rgba(10, 9, 3, 0.22);
+  transform: translateY(-1px);
+  filter: brightness(1.05);
+}
+
+.feedback-submit:focus-visible {
+  outline: none;
+}
+
+@media (max-width: 640px) {
+  .feedback-section__inner {
+    border-radius: 18px;
+    padding: clamp(24px, 8vw, 36px);
+  }
+
+  .feedback-submit {
+    width: 100%;
+  }
+}
+
 @media (max-width: 640px) {
   body.is-fullscreen #toolbarBottom {
     width: min(96vw, 920px);

--- a/index.html
+++ b/index.html
@@ -326,6 +326,57 @@
       </div>
     </section>
 
+    <section class="feedback-section" aria-labelledby="feedbackHeading">
+      <div class="feedback-section__inner">
+        <h2 id="feedbackHeading">Send Feedback</h2>
+        <p class="feedback-description">
+          Have suggestions or want to share how you use Handwriting Repeater? Drop a quick note below and we&rsquo;ll get back to you.
+        </p>
+        <form
+          class="feedback-form"
+          action="mailto:dcjapi@gmail.com"
+          method="post"
+          enctype="text/plain"
+        >
+          <div class="feedback-field">
+            <label class="feedback-label" for="feedbackName">Name</label>
+            <input
+              class="feedback-input"
+              type="text"
+              id="feedbackName"
+              name="name"
+              placeholder="Your name"
+              autocomplete="name"
+            />
+          </div>
+          <div class="feedback-field">
+            <label class="feedback-label" for="feedbackEmail">Email</label>
+            <input
+              class="feedback-input"
+              type="email"
+              id="feedbackEmail"
+              name="email"
+              placeholder="you@example.com"
+              autocomplete="email"
+              required
+            />
+          </div>
+          <div class="feedback-field">
+            <label class="feedback-label" for="feedbackMessage">Message</label>
+            <textarea
+              class="feedback-textarea"
+              id="feedbackMessage"
+              name="message"
+              placeholder="Share your thoughts, ideas, or questions"
+              rows="5"
+              required
+            ></textarea>
+          </div>
+          <button class="feedback-submit" type="submit">Send Email</button>
+        </form>
+      </div>
+    </section>
+
     <input type="file" id="inputPenImage" class="visually-hidden" accept="image/*" aria-hidden="true" />
 
     <div id="pageStylePopover" class="popover" role="dialog" aria-label="Page style options">


### PR DESCRIPTION
## Summary
- add a "Send Feedback" section at the bottom of the page that opens an email to dcjapi@gmail.com
- style the feedback form to match the existing visual theme and remain mobile friendly

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d37af7adf083319387c300856a19a8