### PR TITLE
Reorganize toolbar layout and fullscreen styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -201,9 +201,8 @@ body {
   box-shadow: 0 26px 48px rgba(10, 9, 3, 0.28);
   overflow: visible;
   --zoom-level: 1;
-  --board-width: 1200px;
-  width: min(100%, calc(var(--board-width, 1200px) + 88px));
-  max-width: calc(var(--board-width, 1200px) + 88px);
+  width: min(100%, 1288px);
+  max-width: 1288px;
 }
 
 .writer-board {
@@ -213,13 +212,16 @@ body {
   justify-items: stretch;
   align-items: stretch;
   min-width: 0;
-  width: min(100%, var(--board-width, 1200px));
+  width: min(100%, 1200px);
   aspect-ratio: 2 / 1;
   border-radius: 24px;
   border: 5px solid rgba(255, 130, 0, 0.8);
   background: #ffffff;
   box-shadow: 0 22px 44px rgba(10, 9, 3, 0.24);
   overflow: hidden;
+  transform: scale(var(--zoom-level, 1));
+  transform-origin: center;
+  will-change: transform;
 }
 
 .writer-board canvas {
@@ -227,137 +229,6 @@ body {
   grid-column: 1;
   width: 100%;
   height: 100%;
-}
-
-.board-side-controls {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 30;
-  pointer-events: none;
-}
-
-.board-side-controls__panel {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  padding: 16px;
-  background: rgba(255, 244, 213, 0.96);
-  border: 3px solid rgba(255, 130, 0, 0.85);
-  border-radius: 22px;
-  box-shadow: 0 16px 32px rgba(10, 9, 3, 0.26);
-  pointer-events: auto;
-}
-
-.board-side-controls__panel::after {
-  content: "";
-  position: absolute;
-  top: 50%;
-  right: -10px;
-  transform: translateY(-50%);
-  width: 18px;
-  height: 48px;
-  background: inherit;
-  border: inherit;
-  border-left: none;
-  border-radius: 0 18px 18px 0;
-  box-shadow: none;
-  z-index: -1;
-}
-
-.board-side-controls--left {
-  left: 0;
-  transform: translate(calc(-100% + 18px), -50%);
-}
-
-.board-bookmarks {
-  position: absolute;
-  top: 50%;
-  right: 0;
-  transform: translateY(-50%);
-  display: flex;
-  align-items: center;
-  gap: 0;
-  z-index: 30;
-}
-
-.board-bookmarks__panel {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  padding: 16px 18px 16px 20px;
-  background: rgba(255, 244, 213, 0.96);
-  border: 3px solid rgba(255, 130, 0, 0.85);
-  border-right: none;
-  border-radius: 22px 0 0 22px;
-  box-shadow: 0 16px 32px rgba(10, 9, 3, 0.26);
-  transform: translateX(100%);
-  opacity: 0;
-  pointer-events: none;
-  transition: transform 0.3s ease, opacity 0.3s ease;
-}
-
-.board-bookmarks__panel::before {
-  content: "";
-  position: absolute;
-  top: 50%;
-  left: -10px;
-  transform: translateY(-50%);
-  width: 18px;
-  height: 48px;
-  background: inherit;
-  border: 3px solid rgba(255, 130, 0, 0.85);
-  border-right: none;
-  border-radius: 18px 0 0 18px;
-  box-shadow: none;
-  z-index: -1;
-}
-
-.board-bookmarks.is-expanded .board-bookmarks__panel {
-  transform: translateX(0);
-  opacity: 1;
-  pointer-events: auto;
-}
-
-.board-bookmarks__toggle {
-  width: 56px;
-  height: 60px;
-  border-radius: 0 24px 24px 0;
-  border: 3px solid rgba(255, 130, 0, 0.9);
-  border-left: none;
-  background: linear-gradient(180deg, rgba(255, 130, 0, 0.98) 0%, rgba(255, 201, 41, 0.98) 100%);
-  color: var(--color-smoky-black);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  box-shadow: 0 18px 34px rgba(10, 9, 3, 0.3);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.board-bookmarks__toggle:hover,
-.board-bookmarks__toggle:focus-visible {
-  outline: none;
-  transform: translateX(-2px);
-  box-shadow: 0 22px 42px rgba(10, 9, 3, 0.36);
-}
-
-.board-bookmarks__toggle:active {
-  transform: translateX(0);
-  box-shadow: 0 12px 24px rgba(10, 9, 3, 0.26);
-}
-
-.board-bookmarks__toggle-icon {
-  width: 22px;
-  height: 22px;
-  fill: currentColor;
-  transform: rotate(-90deg);
-  transition: transform 0.3s ease;
-}
-
-.board-bookmarks.is-expanded .board-bookmarks__toggle-icon {
-  transform: rotate(90deg);
 }
 
 #writerPage,
@@ -375,13 +246,16 @@ body {
 
 .board-header {
   position: absolute;
-  top: 16px;
-  right: 16px;
+  top: clamp(18px, 3vw, 28px);
+  left: 50%;
+  transform: translateX(-50%);
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
-  gap: 10px;
+  align-items: center;
+  gap: 12px;
   pointer-events: none;
+  width: min(100%, 1200px);
+  padding: 0 clamp(20px, 4vw, 40px);
 }
 
 #boardDate {
@@ -400,6 +274,8 @@ body {
   cursor: pointer;
   user-select: none;
   transition: transform 0.15s ease;
+  text-align: center;
+  align-self: center;
 }
 
 .board-lesson-title {
@@ -412,8 +288,9 @@ body {
   text-shadow: 0.08em 0.08em rgba(255, 201, 41, 0.26);
   padding: 4px 12px 6px;
   min-height: 1.3em;
-  min-width: clamp(220px, 22vw, 340px);
-  text-align: right;
+  width: 100%;
+  max-width: min(100%, 820px);
+  text-align: center;
   transition: opacity 0.2s ease;
 }
 
@@ -433,6 +310,27 @@ body {
   transform: translateY(0);
   background: rgba(255, 244, 213, 0.9);
   box-shadow: 0 4px 8px rgba(10, 9, 3, 0.24);
+}
+
+body.is-fullscreen .writer-container {
+  background: var(--color-aerospace-orange);
+  border-color: var(--color-aerospace-orange);
+  box-shadow: 0 32px 54px rgba(10, 9, 3, 0.34);
+}
+
+body.is-fullscreen .board-header {
+  width: min(100%, 1200px);
+  padding-right: clamp(28px, 6vw, 56px);
+}
+
+body.is-fullscreen #boardDate {
+  align-self: flex-end;
+  text-align: right;
+}
+
+body.is-fullscreen #boardLessonTitle {
+  align-self: center;
+  margin-top: 4px;
 }
 
 #retroTv {
@@ -547,6 +445,18 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 12px;
+}
+
+.toolbar-group.toolbar-board,
+.toolbar-group.toolbar-zoom,
+.toolbar-group.toolbar-quick {
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+
+.toolbar-group.toolbar-quick {
+  justify-content: flex-end;
 }
 
 .toolbar-group.toolbar-centre {
@@ -1347,24 +1257,6 @@ body.is-fullscreen #toolbarBottom.is-collapsed .toolbar-toggle__icon {
     height: 64px;
   }
 
-  .board-side-controls--left {
-    left: 12px;
-    transform: translate(0, -50%);
-  }
-
-  .board-side-controls__panel::after,
-  .board-bookmarks__panel::before {
-    display: none;
-  }
-
-  .board-bookmarks {
-    right: 12px;
-  }
-
-  .board-bookmarks__toggle {
-    width: 48px;
-    height: 52px;
-  }
 }
 
 .seo-description {
@@ -1412,7 +1304,10 @@ body.is-fullscreen #toolbarBottom.is-collapsed .toolbar-toggle__icon {
 
   .toolbar-group.toolbar-left,
   .toolbar-group.toolbar-right,
-  .toolbar-group.toolbar-centre {
+  .toolbar-group.toolbar-centre,
+  .toolbar-group.toolbar-board,
+  .toolbar-group.toolbar-zoom,
+  .toolbar-group.toolbar-quick {
     flex: 1 1 100%;
     justify-content: center;
   }

--- a/index.html
+++ b/index.html
@@ -90,70 +90,6 @@
 
     <main class="main-container disable-select" role="main">
       <div id="writerContainer" class="writer-container">
-        <div class="board-side-controls board-side-controls--left" role="group" aria-label="Board controls">
-          <div class="board-side-controls__panel">
-            <button class="btn icon" id="btnUndo" type="button" aria-label="Undo" title="Undo">
-              <svg aria-hidden="true"><use href="assets/icons.svg#undo"></use></svg>
-            </button>
-            <button class="btn icon" id="btnRedo" type="button" aria-label="Redo" title="Redo">
-              <svg aria-hidden="true"><use href="assets/icons.svg#redo"></use></svg>
-            </button>
-            <button class="btn icon" id="btnReset" type="button" aria-label="Reset" title="Reset">
-              <svg aria-hidden="true"><use href="assets/icons.svg#reset"></use></svg>
-            </button>
-            <button
-              class="btn icon"
-              id="btnPageStyle"
-              type="button"
-              aria-label="Page style"
-              title="Page style"
-              aria-haspopup="dialog"
-              aria-expanded="false"
-            >
-              <svg aria-hidden="true"><use href="assets/icons.svg#page-lines"></use></svg>
-            </button>
-          </div>
-        </div>
-
-        <div class="board-bookmarks" id="boardBookmarks">
-          <div class="board-bookmarks__panel" id="boardBookmarksPanel" role="group" aria-label="Quick actions" aria-hidden="true">
-            <button
-              class="btn icon"
-              id="btnTimer"
-              type="button"
-              aria-label="Timer"
-              title="Timer"
-              aria-haspopup="dialog"
-              aria-expanded="false"
-              aria-pressed="false"
-              tabindex="-1"
-            >
-              <svg aria-hidden="true"><use href="assets/icons.svg#timer"></use></svg>
-            </button>
-            <button class="btn icon" id="btnUploadPen" type="button" aria-label="Upload pen image" title="Upload pen image" tabindex="-1">
-              <svg aria-hidden="true"><use href="assets/icons.svg#upload"></use></svg>
-            </button>
-            <button class="btn icon is-disabled" id="btnRemovePenImage" type="button" aria-label="Remove custom pen image" title="Remove custom pen image" disabled tabindex="-1">
-              <svg aria-hidden="true"><use href="assets/icons.svg#close"></use></svg>
-            </button>
-            <button class="btn icon" id="btnFullscreen" type="button" aria-label="Fullscreen" title="Fullscreen" tabindex="-1">
-              <svg aria-hidden="true"><use href="assets/icons.svg#fullscreen"></use></svg>
-            </button>
-          </div>
-          <button
-            type="button"
-            class="board-bookmarks__toggle"
-            id="boardBookmarksToggle"
-            aria-controls="boardBookmarksPanel"
-            aria-expanded="false"
-            aria-label="Show quick actions"
-          >
-            <svg class="board-bookmarks__toggle-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-              <path d="M12 16.5 5.5 10l1.41-1.41L12 13.67l5.09-5.08L18.5 10z"></path>
-            </svg>
-          </button>
-        </div>
-
         <div id="writerBoard" class="writer-board">
           <canvas id="writerPage" width="1200" height="600"></canvas>
           <canvas id="writerTrace" width="1200" height="600"></canvas>
@@ -205,7 +141,30 @@
           </svg>
         </button>
         <div class="toolbar-inner">
-          <div class="toolbar-group toolbar-left" role="group" aria-label="Zoom and speed">
+          <div class="toolbar-group toolbar-board" role="group" aria-label="Board controls">
+            <button class="btn icon" id="btnUndo" type="button" aria-label="Undo" title="Undo">
+              <svg aria-hidden="true"><use href="assets/icons.svg#undo"></use></svg>
+            </button>
+            <button class="btn icon" id="btnRedo" type="button" aria-label="Redo" title="Redo">
+              <svg aria-hidden="true"><use href="assets/icons.svg#redo"></use></svg>
+            </button>
+            <button class="btn icon" id="btnReset" type="button" aria-label="Reset" title="Reset">
+              <svg aria-hidden="true"><use href="assets/icons.svg#reset"></use></svg>
+            </button>
+            <button
+              class="btn icon"
+              id="btnPageStyle"
+              type="button"
+              aria-label="Page style"
+              title="Page style"
+              aria-haspopup="dialog"
+              aria-expanded="false"
+            >
+              <svg aria-hidden="true"><use href="assets/icons.svg#page-lines"></use></svg>
+            </button>
+          </div>
+
+          <div class="toolbar-group toolbar-zoom" role="group" aria-label="Zoom and speed">
             <button class="btn icon" id="btnZoomOut" type="button" aria-label="Zoom out" title="Zoom out">
               <svg aria-hidden="true"><use href="assets/icons.svg#zoom-out"></use></svg>
             </button>
@@ -304,6 +263,30 @@
               aria-expanded="false"
             >
               <svg aria-hidden="true"><use href="assets/icons.svg#palette"></use></svg>
+            </button>
+          </div>
+
+          <div class="toolbar-group toolbar-quick" role="group" aria-label="Quick actions">
+            <button
+              class="btn icon"
+              id="btnTimer"
+              type="button"
+              aria-label="Timer"
+              title="Timer"
+              aria-haspopup="dialog"
+              aria-expanded="false"
+              aria-pressed="false"
+            >
+              <svg aria-hidden="true"><use href="assets/icons.svg#timer"></use></svg>
+            </button>
+            <button class="btn icon" id="btnUploadPen" type="button" aria-label="Upload pen image" title="Upload pen image">
+              <svg aria-hidden="true"><use href="assets/icons.svg#upload"></use></svg>
+            </button>
+            <button class="btn icon is-disabled" id="btnRemovePenImage" type="button" aria-label="Remove custom pen image" title="Remove custom pen image" disabled>
+              <svg aria-hidden="true"><use href="assets/icons.svg#close"></use></svg>
+            </button>
+            <button class="btn icon" id="btnFullscreen" type="button" aria-label="Fullscreen" title="Fullscreen">
+              <svg aria-hidden="true"><use href="assets/icons.svg#fullscreen"></use></svg>
             </button>
           </div>
         </div>

--- a/js/Controls.js
+++ b/js/Controls.js
@@ -589,22 +589,6 @@ export class Controls {
 
     setCollapsedState(false);
 
-    const restoreToolbarPosition = () => {
-      if (!this.toolbarOriginalParent || !this.toolbarBottom) {
-        return;
-      }
-
-      if (this.toolbarBottom.parentElement === this.toolbarOriginalParent) {
-        return;
-      }
-
-      if (this.toolbarNextSibling && this.toolbarNextSibling.parentNode === this.toolbarOriginalParent) {
-        this.toolbarOriginalParent.insertBefore(this.toolbarBottom, this.toolbarNextSibling);
-      } else {
-        this.toolbarOriginalParent.appendChild(this.toolbarBottom);
-      }
-    };
-
     const handleFullscreenChange = () => {
       const fullscreenElement = document.fullscreenElement ?? document.webkitFullscreenElement ?? null;
       const isWriterFullscreen = fullscreenElement === this.writerContainer;
@@ -617,20 +601,19 @@ export class Controls {
         body.classList.toggle('is-fullscreen', isAppFullscreen);
       }
 
-      if (isWriterFullscreen) {
-        if (this.writerContainer && this.toolbarBottom.parentElement !== this.writerContainer) {
-          this.writerContainer.appendChild(this.toolbarBottom);
+      if (this.toolbarBottom) {
+        this.toolbarBottom.classList.toggle('is-fullscreen-active', isAppFullscreen);
+
+        if (!isAppFullscreen) {
+          this.toolbarBottom.classList.remove('is-collapsed');
+          setCollapsedState(false);
         }
-      } else {
-        restoreToolbarPosition();
-        this.toolbarBottom.classList.remove('is-collapsed');
-        setCollapsedState(false);
       }
     };
 
     if (this.toolbarToggleButton) {
       this.toolbarToggleButton.addEventListener('click', () => {
-        if (!document.body?.classList.contains('is-fullscreen')) {
+        if (!this.toolbarBottom.classList.contains('is-fullscreen-active')) {
           return;
         }
         const isCollapsed = this.toolbarBottom.classList.toggle('is-collapsed');
@@ -896,16 +879,12 @@ export class Controls {
   setZoom(value, persist = true) {
     const zoom = clamp(Number(value) || DEFAULT_SETTINGS.zoomLevel, 0.5, 3);
     this.userData.userSettings.zoomLevel = zoom;
-    const boardWidth = CANVAS_WIDTH * zoom;
     if (this.writerContainer) {
-      this.writerContainer.style.transform = '';
-      this.writerContainer.style.transformOrigin = '';
       this.writerContainer.style.setProperty('--zoom-level', String(zoom));
-      this.writerContainer.style.setProperty('--board-width', `${boardWidth}px`);
     }
 
     if (this.writerBoard) {
-      this.writerBoard.style.setProperty('--board-width', `${boardWidth}px`);
+      this.writerBoard.style.setProperty('--zoom-level', String(zoom));
     }
 
     if (persist) {


### PR DESCRIPTION
## Summary
- move board reset/background and quick action buttons back into the bottom toolbar
- center the lesson title below the date and restyle fullscreen with an aerospace orange surround
- adjust zoom handling and fullscreen toolbar logic so the board scales without resizing and controls stay movable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d37d1f31048331a9ee3db87ec01b45