### PR TITLE
Extend fullscreen board to edges and reorganize toolbar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -26,6 +26,10 @@ body {
   color: var(--color-crosstik);
 }
 
+body.is-fullscreen {
+  overflow: hidden;
+}
+
 .title-container {
   position: relative;
   width: 100%;
@@ -84,19 +88,14 @@ body {
   color: var(--color-smoky-black);
 }
 
-.lesson-controls {
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  padding: 0 16px 16px;
-}
-
 .lesson-title-field {
-  width: min(100%, 380px);
+  width: 100%;
+  max-width: 420px;
   display: flex;
   flex-direction: column;
   gap: 8px;
   color: var(--color-smoky-black);
+  margin: 0 auto;
 }
 
 .lesson-title-input-row {
@@ -220,6 +219,31 @@ body {
   background: #ffffff;
   box-shadow: 0 22px 44px rgba(10, 9, 3, 0.24);
   overflow: hidden;
+}
+
+body.is-fullscreen .writer-container {
+  width: 100vw;
+  max-width: none;
+  height: 100vh;
+  padding: 0;
+  border-radius: 0;
+  border: none;
+  box-shadow: none;
+  background: #ffffff;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: stretch;
+}
+
+body.is-fullscreen .writer-board {
+  width: 100%;
+  height: 100%;
+  aspect-ratio: auto;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  flex: 1 1 auto;
 }
 
 .writer-board canvas {
@@ -505,6 +529,8 @@ body {
   color: var(--color-smoky-black);
   z-index: 20;
   --toolbar-toggle-visible: 56px;
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
 }
 
 .toolbar-drag-handle {
@@ -534,13 +560,24 @@ body {
 
 .toolbar-inner {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: 16px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 20px;
   width: 100%;
-  overflow-x: auto;
-  scrollbar-width: thin;
+}
+
+.toolbar-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+}
+
+.toolbar-details {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
 }
 
 .toolbar-group {
@@ -554,15 +591,24 @@ body {
   justify-content: center;
 }
 
-.toolbar-group.toolbar-teach {
-  flex: 1 1 100%;
-  flex-direction: column;
-  align-items: stretch;
-  gap: 12px;
+.toolbar-lesson,
+.toolbar-teach {
   background: rgba(255, 255, 255, 0.74);
   border-radius: 16px;
-  padding: 12px 16px 16px;
+  padding: 16px 18px 18px;
   box-shadow: inset 0 0 0 1px rgba(10, 9, 3, 0.08);
+}
+
+.toolbar-lesson {
+  display: flex;
+  justify-content: center;
+  padding-bottom: 20px;
+}
+
+.toolbar-teach {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .teach-field {
@@ -860,8 +906,9 @@ body {
 }
 .toolbar-group.toolbar-left,
 .toolbar-group.toolbar-right {
-  flex: 1 1 auto;
-  justify-content: flex-start;
+  flex: 1 1 220px;
+  justify-content: center;
+  flex-wrap: wrap;
 }
 
 .btn.icon {
@@ -979,6 +1026,7 @@ body.is-fullscreen #toolbarBottom {
   margin: 0;
   padding: 62px 24px 28px;
   z-index: 1000;
+  max-height: calc(100vh - 32px);
   transition: transform 0.3s ease;
 }
 
@@ -1528,6 +1576,10 @@ body.is-fullscreen #toolbarBottom.is-collapsed .toolbar-toggle__icon {
     width: auto;
   }
 
+  .toolbar-controls {
+    flex-direction: column;
+  }
+
   .toolbar-group.toolbar-left,
   .toolbar-group.toolbar-right,
   .toolbar-group.toolbar-centre {
@@ -1535,8 +1587,9 @@ body.is-fullscreen #toolbarBottom.is-collapsed .toolbar-toggle__icon {
     justify-content: center;
   }
 
-  .toolbar-group.toolbar-teach {
-    padding: 10px 12px 14px;
+  .toolbar-lesson,
+  .toolbar-teach {
+    padding: 14px 12px 16px;
   }
 
   .teach-input-row {

--- a/index.html
+++ b/index.html
@@ -65,29 +65,6 @@
       </div>
     </header>
 
-    <section class="lesson-controls" aria-label="Lesson details">
-      <div class="lesson-title-field">
-        <label class="lesson-title-label" for="inputLessonTitle">Lesson title</label>
-        <div class="lesson-title-input-row">
-          <input
-            type="text"
-            id="inputLessonTitle"
-            class="lesson-title-input"
-            placeholder="Lesson title here"
-            autocomplete="off"
-          />
-          <button
-            type="button"
-            id="btnLessonTitleApply"
-            class="lesson-title-apply is-disabled"
-            disabled
-          >
-            Display
-          </button>
-        </div>
-      </div>
-    </section>
-
     <main class="main-container disable-select" role="main">
       <div id="writerContainer" class="writer-container">
         <div class="board-side-controls board-side-controls--left" role="group" aria-label="Board controls">
@@ -205,106 +182,133 @@
           </svg>
         </button>
         <div class="toolbar-inner">
-          <div class="toolbar-group toolbar-left" role="group" aria-label="Zoom and speed">
-            <button class="btn icon" id="btnZoomOut" type="button" aria-label="Zoom out" title="Zoom out">
-              <svg aria-hidden="true"><use href="assets/icons.svg#zoom-out"></use></svg>
-            </button>
-            <button class="btn icon" id="btnZoomIn" type="button" aria-label="Zoom in" title="Zoom in">
-              <svg aria-hidden="true"><use href="assets/icons.svg#zoom-in"></use></svg>
-            </button>
-            <div class="slider-control" id="speedControl">
-              <span class="icon-leading" aria-hidden="true">
-                <svg><use href="assets/icons.svg#speed"></use></svg>
-              </span>
-              <label class="visually-hidden" for="sliderSpeed">Rewrite speed</label>
-              <input
-                id="sliderSpeed"
-                class="slider"
-                type="range"
-                min="0.5"
-                max="8"
-                step="0.1"
-                value="2"
-                aria-valuemin="0.5"
-                aria-valuemax="8"
-                aria-valuenow="2"
-                aria-label="Rewrite speed"
-              />
-            </div>
-          </div>
-
-          <div class="toolbar-group toolbar-centre" role="group" aria-label="Playback">
-            <button class="btn icon btn-primary" id="btnRewrite" type="button" aria-label="Rewrite" title="Rewrite" aria-pressed="false">
-              <svg aria-hidden="true"><use href="assets/icons.svg#play"></use></svg>
-            </button>
-          </div>
-
-          <div class="toolbar-group toolbar-teach" role="group" aria-label="Teaching text controls">
-            <div class="teach-field">
-              <label class="teach-label" for="teachTextInput">Practice text</label>
-              <div class="teach-input-row">
+          <div class="toolbar-controls" role="group" aria-label="Board customization controls">
+            <div class="toolbar-group toolbar-left" role="group" aria-label="Zoom and speed">
+              <button class="btn icon" id="btnZoomOut" type="button" aria-label="Zoom out" title="Zoom out">
+                <svg aria-hidden="true"><use href="assets/icons.svg#zoom-out"></use></svg>
+              </button>
+              <button class="btn icon" id="btnZoomIn" type="button" aria-label="Zoom in" title="Zoom in">
+                <svg aria-hidden="true"><use href="assets/icons.svg#zoom-in"></use></svg>
+              </button>
+              <div class="slider-control" id="speedControl">
+                <span class="icon-leading" aria-hidden="true">
+                  <svg><use href="assets/icons.svg#speed"></use></svg>
+                </span>
+                <label class="visually-hidden" for="sliderSpeed">Rewrite speed</label>
                 <input
-                  id="teachTextInput"
-                  class="teach-input"
-                  type="text"
-                  placeholder="Type a sentence for the board"
-                  autocomplete="off"
+                  id="sliderSpeed"
+                  class="slider"
+                  type="range"
+                  min="0.5"
+                  max="8"
+                  step="0.1"
+                  value="2"
+                  aria-valuemin="0.5"
+                  aria-valuemax="8"
+                  aria-valuenow="2"
+                  aria-label="Rewrite speed"
                 />
-                <button class="teach-button" id="btnTeach" type="button">Teach</button>
-                <button class="teach-button" id="btnTeachNext" type="button" disabled>
-                  Next
-                  <span aria-hidden="true" class="teach-button__arrow">➜</span>
-                </button>
               </div>
             </div>
-            <div class="teach-field teach-preview-block">
-              <div class="teach-preview__header">
-                <p class="teach-label teach-preview__title">Freeze letters</p>
-                <button
-                  type="button"
-                  id="btnToggleFreezePreview"
-                  class="teach-preview__toggle"
-                  aria-controls="teachPreview"
-                  aria-expanded="true"
-                >
-                  Hide letters
-                </button>
+
+            <div class="toolbar-group toolbar-centre" role="group" aria-label="Playback">
+              <button class="btn icon btn-primary" id="btnRewrite" type="button" aria-label="Rewrite" title="Rewrite" aria-pressed="false">
+                <svg aria-hidden="true"><use href="assets/icons.svg#play"></use></svg>
+              </button>
+            </div>
+
+            <div class="toolbar-group toolbar-right" role="group" aria-label="Pen controls">
+              <div class="slider-control" id="penSizeControl">
+                <span class="icon-leading" aria-hidden="true">
+                  <svg><use href="assets/icons.svg#pen"></use></svg>
+                </span>
+                <label class="visually-hidden" for="sliderPenSize">Pen size</label>
+                <input
+                  id="sliderPenSize"
+                  class="slider"
+                  type="range"
+                  min="1"
+                  max="40"
+                  value="6"
+                  step="1"
+                  aria-valuemin="1"
+                  aria-valuemax="40"
+                  aria-valuenow="6"
+                  aria-label="Pen size"
+                />
               </div>
-              <div class="teach-preview" id="teachPreview" aria-label="Sentence letter controls"></div>
+              <button
+                class="btn icon"
+                id="btnPalette"
+                type="button"
+                aria-label="Pen colour"
+                title="Pen colour"
+                aria-haspopup="dialog"
+                aria-expanded="false"
+              >
+                <svg aria-hidden="true"><use href="assets/icons.svg#palette"></use></svg>
+              </button>
             </div>
           </div>
 
-          <div class="toolbar-group toolbar-right" role="group" aria-label="Pen controls">
-            <div class="slider-control" id="penSizeControl">
-              <span class="icon-leading" aria-hidden="true">
-                <svg><use href="assets/icons.svg#pen"></use></svg>
-              </span>
-              <label class="visually-hidden" for="sliderPenSize">Pen size</label>
-              <input
-                id="sliderPenSize"
-                class="slider"
-                type="range"
-                min="1"
-                max="40"
-                value="6"
-                step="1"
-                aria-valuemin="1"
-                aria-valuemax="40"
-                aria-valuenow="6"
-                aria-label="Pen size"
-              />
+          <div class="toolbar-details">
+            <div class="toolbar-lesson" role="group" aria-label="Lesson title">
+              <div class="lesson-title-field">
+                <label class="lesson-title-label" for="inputLessonTitle">Lesson title</label>
+                <div class="lesson-title-input-row">
+                  <input
+                    type="text"
+                    id="inputLessonTitle"
+                    class="lesson-title-input"
+                    placeholder="Lesson title here"
+                    autocomplete="off"
+                  />
+                  <button
+                    type="button"
+                    id="btnLessonTitleApply"
+                    class="lesson-title-apply is-disabled"
+                    disabled
+                  >
+                    Display
+                  </button>
+                </div>
+              </div>
             </div>
-            <button
-              class="btn icon"
-              id="btnPalette"
-              type="button"
-              aria-label="Pen colour"
-              title="Pen colour"
-              aria-haspopup="dialog"
-              aria-expanded="false"
-            >
-              <svg aria-hidden="true"><use href="assets/icons.svg#palette"></use></svg>
-            </button>
+
+            <div class="toolbar-teach" role="group" aria-label="Teaching text controls">
+              <div class="teach-field">
+                <label class="teach-label" for="teachTextInput">Practice text</label>
+                <div class="teach-input-row">
+                  <input
+                    id="teachTextInput"
+                    class="teach-input"
+                    type="text"
+                    placeholder="Type a sentence for the board"
+                    autocomplete="off"
+                  />
+                  <button class="teach-button" id="btnTeach" type="button">Teach</button>
+                  <button class="teach-button" id="btnTeachNext" type="button" disabled>
+                    Next
+                    <span aria-hidden="true" class="teach-button__arrow">➜</span>
+                  </button>
+                </div>
+              </div>
+              <div class="teach-field teach-preview-block">
+                <div class="teach-preview__header">
+                  <p class="teach-label teach-preview__title">Freeze letters</p>
+                  <button
+                    type="button"
+                    id="btnToggleFreezePreview"
+                    class="teach-preview__toggle"
+                    aria-controls="teachPreview"
+                    aria-expanded="true"
+                  >
+                    Hide letters
+                  </button>
+                </div>
+                <div class="teach-preview" id="teachPreview" aria-label="Sentence letter controls"></div>
+              </div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Expand the fullscreen writer container to cover the full viewport and keep the toolbar accessible at the bottom.
- Restructure the toolbar layout so board customization buttons sit above the lesson title and practice text controls.
- Allow the toolbar to scroll when tall and update responsive styling for the new layout.

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d37e45ae108331a5f2a970835791c6