### PR TITLE
Align board date to left side

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -276,7 +276,7 @@ body {
   transform: translateX(-50%);
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
   gap: 12px;
   pointer-events: none;
   width: min(100%, 1200px);
@@ -299,8 +299,8 @@ body {
   cursor: pointer;
   user-select: none;
   transition: transform 0.15s ease;
-  text-align: center;
-  align-self: center;
+  text-align: left;
+  align-self: flex-start;
 }
 
 .board-lesson-title {


### PR DESCRIPTION
## Summary
- align the board header layout so its children can sit flush with the board edge
- left-align the date chip so it appears on the side of the handwriting board

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d38e5e75948331ad581d575f939c6e