### PR TITLE
Refine toolbar layout and fullscreen behaviour

### DIFF
--- a/assets/icons.svg
+++ b/assets/icons.svg
@@ -20,6 +20,20 @@
     <line x1="12" y1="11.2" x2="12" y2="9.2" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" />
     <line x1="16" y1="13.2" x2="14.8" y2="11.4" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" />
   </symbol>
+  <symbol id="turtle" viewBox="0 0 24 24">
+    <path
+      d="M4 13c0-3.3 3.1-6 8-6s8 2.7 8 6v2c0 1.1-.9 2-2 2H6c-1.1 0-2-.9-2-2z"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linejoin="round"
+    />
+    <path d="M7 17l-1 3" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+    <path d="M17 17l1 3" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+    <path d="M12 7V5" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+    <path d="M4 13l-1.5-1" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+    <circle cx="20.5" cy="12" r="1.2" fill="currentColor" />
+  </symbol>
   <symbol id="play" viewBox="0 0 24 24">
     <path d="M8 5v14l11-7z" fill="currentColor" />
   </symbol>

--- a/css/style.css
+++ b/css/style.css
@@ -87,10 +87,9 @@ body {
 
 .toolbar-controls {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  gap: 16px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: clamp(18px, 4vw, 28px);
   width: 100%;
 }
 
@@ -213,16 +212,16 @@ body {
 
 .writer-container {
   position: relative;
-  display: grid;
-  grid-template-columns: 1fr;
-  justify-items: center;
+  display: flex;
+  flex-direction: column;
   align-items: center;
+  gap: clamp(20px, 4vw, 36px);
   touch-action: none;
   background: linear-gradient(180deg, rgba(255, 201, 41, 0.28) 0%, rgba(255, 244, 213, 0.96) 100%);
   border-radius: 28px;
   border: 6px solid rgba(255, 130, 0, 0.85);
   padding: clamp(20px, 3vw, 28px);
-  padding-bottom: clamp(96px, 12vw, 140px);
+  padding-bottom: clamp(28px, 4vw, 40px);
   box-shadow: 0 26px 48px rgba(10, 9, 3, 0.28);
   overflow: visible;
   --zoom-level: 1;
@@ -360,14 +359,17 @@ body.is-fullscreen .writer-container {
   border: none;
   box-shadow: none;
   border-radius: 0;
-  padding: 0;
+  padding: clamp(20px, 5vh, 40px) clamp(28px, 6vw, 56px) clamp(28px, 5vh, 48px);
   width: 100vw;
   max-width: none;
-  min-height: calc(100vh - var(--fullscreen-toolbar-offset, 0px));
-  height: calc(100vh - var(--fullscreen-toolbar-offset, 0px));
+  min-height: 100vh;
+  height: 100vh;
   display: flex;
-  justify-content: center;
-  align-items: flex-start;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  gap: clamp(24px, 5vh, 40px);
+  box-sizing: border-box;
 }
 
 body.is-fullscreen .writer-board {
@@ -419,6 +421,10 @@ body.is-fullscreen #timerProgress {
   opacity: 0.4;
 }
 
+#retroTv.tv-off {
+  display: none;
+}
+
 #retroTv .tv-frame {
   width: 100%;
   aspect-ratio: 4 / 3;
@@ -463,73 +469,60 @@ body.is-fullscreen #timerProgress {
 }
 
 #toolbarBottom {
-  position: fixed;
-  top: auto;
-  left: 50%;
-  right: auto;
-  bottom: clamp(16px, 4vw, 32px);
-  transform: translate(-50%, 0);
-  width: min(var(--board-width, 1200px), 100vw);
-  max-width: 100vw;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: min(var(--board-width, 1200px), 100%);
+  margin: clamp(12px, 3vw, 24px) auto 0;
   background: rgba(255, 244, 213, 0.94);
   border-radius: 24px;
-  padding: 64px 28px 32px;
   box-shadow: 0 20px 36px rgba(10, 9, 3, 0.18);
   border: 1px solid rgba(10, 9, 3, 0.12);
   backdrop-filter: blur(8px);
-  margin: 0;
   color: var(--color-smoky-black);
   z-index: 20;
-  --toolbar-toggle-visible: 68px;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  --toolbar-base-padding-top: clamp(20px, 3vw, 24px);
+  --toolbar-toggle-visible: 0px;
+  padding-top: calc(var(--toolbar-base-padding-top) + var(--toolbar-toggle-visible));
+  padding-right: clamp(20px, 4vw, 32px);
+  padding-bottom: clamp(20px, 3vw, 28px);
+  padding-left: clamp(20px, 4vw, 32px);
+  overflow: hidden;
+  transition: box-shadow 0.3s ease;
+}
+
+#toolbarBottom.is-fullscreen-active {
+  --toolbar-toggle-visible: 44px;
 }
 
 #toolbarBottom.is-collapsed {
-  transform: translate(-50%, calc(100% - var(--toolbar-toggle-visible)));
+  padding-bottom: clamp(10px, 2vw, 16px);
   box-shadow: 0 14px 28px rgba(10, 9, 3, 0.18);
 }
 
-#toolbarBottom.is-collapsed .toolbar-drag-handle,
 #toolbarBottom.is-collapsed .toolbar-inner {
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
 }
 
-.toolbar-drag-handle {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding-bottom: 8px;
-  cursor: grab;
-  touch-action: none;
-  transition: opacity 0.2s ease;
-}
-
-.toolbar-drag-handle:active {
-  cursor: grabbing;
-}
-
-.toolbar-drag-grip {
-  width: 64px;
-  height: 6px;
-  border-radius: 999px;
-  background: rgba(10, 9, 3, 0.28);
-  box-shadow: 0 2px 6px rgba(10, 9, 3, 0.15);
-}
-
-#toolbarBottom.is-dragging .toolbar-drag-grip {
-  background: rgba(10, 9, 3, 0.45);
-}
-
 .toolbar-inner {
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: 20px;
+  gap: clamp(18px, 4vw, 28px);
   width: 100%;
   overflow: visible;
   transition: opacity 0.2s ease;
+}
+
+.toolbar-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(12px, 3vw, 20px);
+  justify-content: center;
+  align-items: stretch;
 }
 
 .toolbar-group {
@@ -539,16 +532,19 @@ body.is-fullscreen #timerProgress {
   min-width: 0;
 }
 
-.toolbar-group.toolbar-board,
-.toolbar-group.toolbar-zoom,
-.toolbar-group.toolbar-right,
-.toolbar-group.toolbar-quick {
-  flex: 1 1 220px;
-  flex-wrap: wrap;
+.toolbar-row--primary .toolbar-group {
+  flex: 1 1 180px;
   justify-content: center;
 }
 
-.toolbar-group.toolbar-centre {
+.toolbar-group.toolbar-board,
+.toolbar-group.toolbar-zoom,
+.toolbar-group.toolbar-pen,
+.toolbar-group.toolbar-quick {
+  flex-wrap: wrap;
+}
+
+.toolbar-group.toolbar-playback {
   flex: 0 1 auto;
   justify-content: center;
 }
@@ -857,12 +853,6 @@ body.is-fullscreen #timerProgress {
 .teach-letter--other {
   color: #111111;
 }
-.toolbar-group.toolbar-left,
-.toolbar-group.toolbar-right {
-  flex: 1 1 auto;
-  justify-content: center;
-}
-
 .btn.icon {
   position: relative;
   width: 52px;
@@ -930,7 +920,7 @@ body.is-fullscreen #timerProgress {
 }
 
 #toolbarToggle {
-  display: inline-flex;
+  display: none;
   position: absolute;
   top: 12px;
   left: 50%;
@@ -948,6 +938,10 @@ body.is-fullscreen #timerProgress {
   padding: 0;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
   z-index: 2;
+}
+
+#toolbarBottom.is-fullscreen-active #toolbarToggle {
+  display: inline-flex;
 }
 
 #toolbarToggle svg {
@@ -974,10 +968,11 @@ body.is-fullscreen #timerProgress {
 }
 
 body.is-fullscreen #toolbarBottom {
-  bottom: clamp(16px, 3vh, 32px);
-  padding: 64px clamp(20px, 4vw, 32px) clamp(20px, 4vw, 32px);
+  margin-top: auto;
+  margin-bottom: clamp(16px, 4vw, 28px);
   width: min(var(--board-width, 1200px), 100vw);
-  z-index: 1000;
+  padding-right: clamp(28px, 6vw, 48px);
+  padding-left: clamp(28px, 6vw, 48px);
 }
 
 .btn.icon.is-active {
@@ -1312,10 +1307,20 @@ body.is-fullscreen #toolbarBottom {
 @media (max-width: 900px) {
   .writer-container {
     padding: 18px;
-    padding-bottom: clamp(120px, 32vw, 200px);
+    padding-bottom: clamp(24px, 6vw, 40px);
+    gap: clamp(16px, 6vw, 28px);
+  }
+
+  #toolbarBottom {
+    padding-right: clamp(16px, 5vw, 28px);
+    padding-left: clamp(16px, 5vw, 28px);
   }
 
   .toolbar-inner {
+    gap: 16px;
+  }
+
+  .toolbar-row {
     gap: 14px;
   }
 
@@ -1485,14 +1490,16 @@ body.is-fullscreen #toolbarBottom {
 @media (max-width: 640px) {
   body.is-fullscreen #toolbarBottom {
     width: min(var(--board-width, 1200px), 100vw);
-    padding: 60px 16px 24px;
+    padding-right: clamp(12px, 6vw, 20px);
+    padding-left: clamp(12px, 6vw, 20px);
+    --toolbar-toggle-visible: 40px;
   }
 
   #toolbarBottom {
-    padding: 56px 16px 24px;
-    bottom: 12px;
     width: min(var(--board-width, 1200px), calc(100vw - 24px));
-    --toolbar-toggle-visible: 64px;
+    padding-right: clamp(12px, 6vw, 20px);
+    padding-left: clamp(12px, 6vw, 20px);
+    --toolbar-base-padding-top: clamp(18px, 5vw, 26px);
   }
 
   #toolbarToggle {
@@ -1501,19 +1508,23 @@ body.is-fullscreen #toolbarBottom {
   }
 
   .toolbar-controls {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 16px;
+    gap: 14px;
   }
 
-  .toolbar-group.toolbar-left,
-  .toolbar-group.toolbar-right,
-  .toolbar-group.toolbar-centre,
+  .toolbar-row {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .toolbar-group {
+    justify-content: center;
+  }
+
   .toolbar-group.toolbar-board,
   .toolbar-group.toolbar-zoom,
+  .toolbar-group.toolbar-pen,
   .toolbar-group.toolbar-quick {
     flex: 1 1 100%;
-    justify-content: center;
   }
 
   .toolbar-sections {

--- a/index.html
+++ b/index.html
@@ -93,203 +93,201 @@
         </div>
 
         <div id="timerProgress" aria-hidden="true"></div>
-      </div>
-
-      <div id="toolbarBottom" role="toolbar" aria-label="Handwriting controls" class="disable-select">
         <div
-          class="toolbar-drag-handle"
-          id="toolbarDragHandle"
-          role="presentation"
-          aria-hidden="true"
-          title="Drag toolbar"
+          id="toolbarBottom"
+          role="toolbar"
+          aria-label="Handwriting controls"
+          class="disable-select"
         >
-          <span class="toolbar-drag-grip" aria-hidden="true"></span>
-        </div>
-
-        <button
-          id="toolbarToggle"
-          class="toolbar-toggle"
-          type="button"
-          aria-label="Hide controls"
-          aria-expanded="true"
-        >
-          <svg class="toolbar-toggle__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-            <path d="M12 16.5 5.5 10l1.41-1.41L12 13.67l5.09-5.08L18.5 10z"></path>
-          </svg>
-        </button>
-        <div class="toolbar-inner">
-          <div class="toolbar-controls" aria-label="Board customisation controls">
-            <div class="toolbar-group toolbar-board" role="group" aria-label="Board controls">
-            <button class="btn icon" id="btnUndo" type="button" aria-label="Undo" title="Undo">
-              <svg aria-hidden="true"><use href="assets/icons.svg#undo"></use></svg>
-            </button>
-            <button class="btn icon" id="btnRedo" type="button" aria-label="Redo" title="Redo">
-              <svg aria-hidden="true"><use href="assets/icons.svg#redo"></use></svg>
-            </button>
-            <button class="btn icon" id="btnReset" type="button" aria-label="Reset" title="Reset">
-              <svg aria-hidden="true"><use href="assets/icons.svg#reset"></use></svg>
-            </button>
-            <button
-              class="btn icon"
-              id="btnPageStyle"
-              type="button"
-              aria-label="Page style"
-              title="Page style"
-              aria-haspopup="dialog"
-              aria-expanded="false"
-            >
-              <svg aria-hidden="true"><use href="assets/icons.svg#page-lines"></use></svg>
-            </button>
-            </div>
-
-            <div class="toolbar-group toolbar-zoom" role="group" aria-label="Zoom and speed">
-            <button class="btn icon" id="btnZoomOut" type="button" aria-label="Zoom out" title="Zoom out">
-              <svg aria-hidden="true"><use href="assets/icons.svg#zoom-out"></use></svg>
-            </button>
-            <button class="btn icon" id="btnZoomIn" type="button" aria-label="Zoom in" title="Zoom in">
-              <svg aria-hidden="true"><use href="assets/icons.svg#zoom-in"></use></svg>
-            </button>
-            <div class="slider-control" id="speedControl">
-              <span class="icon-leading" aria-hidden="true">
-                <svg><use href="assets/icons.svg#speed"></use></svg>
-              </span>
-              <label class="visually-hidden" for="sliderSpeed">Rewrite speed</label>
-              <input
-                id="sliderSpeed"
-                class="slider"
-                type="range"
-                min="0.5"
-                max="8"
-                step="0.1"
-                value="2"
-                aria-valuemin="0.5"
-                aria-valuemax="8"
-                aria-valuenow="2"
-                aria-label="Rewrite speed"
-              />
-            </div>
-            </div>
-
-            <div class="toolbar-group toolbar-centre" role="group" aria-label="Playback">
-            <button class="btn icon btn-primary" id="btnRewrite" type="button" aria-label="Rewrite" title="Rewrite" aria-pressed="false">
-              <svg aria-hidden="true"><use href="assets/icons.svg#play"></use></svg>
-            </button>
-            </div>
-
-            <div class="toolbar-group toolbar-right" role="group" aria-label="Pen controls">
-            <div class="slider-control" id="penSizeControl">
-              <span class="icon-leading" aria-hidden="true">
-                <svg><use href="assets/icons.svg#pen"></use></svg>
-              </span>
-              <label class="visually-hidden" for="sliderPenSize">Pen size</label>
-              <input
-                id="sliderPenSize"
-                class="slider"
-                type="range"
-                min="1"
-                max="40"
-                value="6"
-                step="1"
-                aria-valuemin="1"
-                aria-valuemax="40"
-                aria-valuenow="6"
-                aria-label="Pen size"
-              />
-            </div>
-            <button
-              class="btn icon"
-              id="btnPalette"
-              type="button"
-              aria-label="Pen colour"
-              title="Pen colour"
-              aria-haspopup="dialog"
-              aria-expanded="false"
-            >
-              <svg aria-hidden="true"><use href="assets/icons.svg#palette"></use></svg>
-            </button>
-            </div>
-
-            <div class="toolbar-group toolbar-quick" role="group" aria-label="Quick actions">
-            <button
-              class="btn icon"
-              id="btnTimer"
-              type="button"
-              aria-label="Timer"
-              title="Timer"
-              aria-haspopup="dialog"
-              aria-expanded="false"
-              aria-pressed="false"
-            >
-              <svg aria-hidden="true"><use href="assets/icons.svg#timer"></use></svg>
-            </button>
-            <button class="btn icon" id="btnUploadPen" type="button" aria-label="Upload pen image" title="Upload pen image">
-              <svg aria-hidden="true"><use href="assets/icons.svg#upload"></use></svg>
-            </button>
-            <button class="btn icon is-disabled" id="btnRemovePenImage" type="button" aria-label="Remove custom pen image" title="Remove custom pen image" disabled>
-              <svg aria-hidden="true"><use href="assets/icons.svg#close"></use></svg>
-            </button>
-            <button class="btn icon" id="btnFullscreen" type="button" aria-label="Fullscreen" title="Fullscreen">
-              <svg aria-hidden="true"><use href="assets/icons.svg#fullscreen"></use></svg>
-            </button>
-            </div>
-          </div>
-
-          <div class="toolbar-sections">
-            <div class="toolbar-card toolbar-lesson" role="group" aria-label="Lesson title controls">
-              <div class="lesson-title-field">
-                <label class="lesson-title-label" for="inputLessonTitle">Lesson title</label>
-                <div class="lesson-title-input-row">
-                  <input
-                    type="text"
-                    id="inputLessonTitle"
-                    class="lesson-title-input"
-                    placeholder="Lesson title here"
-                    autocomplete="off"
-                  />
+          <button
+            id="toolbarToggle"
+            class="toolbar-toggle"
+            type="button"
+            aria-label="Hide controls"
+            aria-expanded="true"
+          >
+            <svg class="toolbar-toggle__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M12 16.5 5.5 10l1.41-1.41L12 13.67l5.09-5.08L18.5 10z"></path>
+            </svg>
+          </button>
+          <div class="toolbar-inner">
+            <div class="toolbar-controls" aria-label="Board customisation controls">
+              <div class="toolbar-row toolbar-row--primary">
+                <div class="toolbar-group toolbar-board" role="group" aria-label="Board controls">
+                  <button class="btn icon" id="btnUndo" type="button" aria-label="Undo" title="Undo">
+                    <svg aria-hidden="true"><use href="assets/icons.svg#undo"></use></svg>
+                  </button>
+                  <button class="btn icon" id="btnRedo" type="button" aria-label="Redo" title="Redo">
+                    <svg aria-hidden="true"><use href="assets/icons.svg#redo"></use></svg>
+                  </button>
+                  <button class="btn icon" id="btnReset" type="button" aria-label="Reset" title="Reset">
+                    <svg aria-hidden="true"><use href="assets/icons.svg#reset"></use></svg>
+                  </button>
                   <button
+                    class="btn icon"
+                    id="btnPageStyle"
                     type="button"
-                    id="btnLessonTitleApply"
-                    class="lesson-title-apply is-disabled"
-                    disabled
+                    aria-label="Page style"
+                    title="Page style"
+                    aria-haspopup="dialog"
+                    aria-expanded="false"
                   >
-                    Display
+                    <svg aria-hidden="true"><use href="assets/icons.svg#page-lines"></use></svg>
+                  </button>
+                </div>
+
+                <div class="toolbar-group toolbar-zoom" role="group" aria-label="Zoom and speed">
+                  <button class="btn icon" id="btnZoomOut" type="button" aria-label="Zoom out" title="Zoom out">
+                    <svg aria-hidden="true"><use href="assets/icons.svg#zoom-out"></use></svg>
+                  </button>
+                  <button class="btn icon" id="btnZoomIn" type="button" aria-label="Zoom in" title="Zoom in">
+                    <svg aria-hidden="true"><use href="assets/icons.svg#zoom-in"></use></svg>
+                  </button>
+                  <div class="slider-control" id="speedControl">
+                    <span class="icon-leading" aria-hidden="true">
+                      <svg><use href="assets/icons.svg#turtle"></use></svg>
+                    </span>
+                    <label class="visually-hidden" for="sliderSpeed">Rewrite speed</label>
+                    <input
+                      id="sliderSpeed"
+                      class="slider"
+                      type="range"
+                      min="0.5"
+                      max="8"
+                      step="0.1"
+                      value="2"
+                      aria-valuemin="0.5"
+                      aria-valuemax="8"
+                      aria-valuenow="2"
+                      aria-label="Rewrite speed"
+                    />
+                  </div>
+                </div>
+
+                <div class="toolbar-group toolbar-playback" role="group" aria-label="Playback">
+                  <button class="btn icon btn-primary" id="btnRewrite" type="button" aria-label="Rewrite" title="Rewrite" aria-pressed="false">
+                    <svg aria-hidden="true"><use href="assets/icons.svg#play"></use></svg>
+                  </button>
+                </div>
+              </div>
+
+              <div class="toolbar-row toolbar-row--secondary">
+                <div class="toolbar-group toolbar-pen" role="group" aria-label="Pen controls">
+                  <div class="slider-control" id="penSizeControl">
+                    <span class="icon-leading" aria-hidden="true">
+                      <svg><use href="assets/icons.svg#pen"></use></svg>
+                    </span>
+                    <label class="visually-hidden" for="sliderPenSize">Pen size</label>
+                    <input
+                      id="sliderPenSize"
+                      class="slider"
+                      type="range"
+                      min="1"
+                      max="40"
+                      value="6"
+                      step="1"
+                      aria-valuemin="1"
+                      aria-valuemax="40"
+                      aria-valuenow="6"
+                      aria-label="Pen size"
+                    />
+                  </div>
+                  <button
+                    class="btn icon"
+                    id="btnPalette"
+                    type="button"
+                    aria-label="Pen colour"
+                    title="Pen colour"
+                    aria-haspopup="dialog"
+                    aria-expanded="false"
+                  >
+                    <svg aria-hidden="true"><use href="assets/icons.svg#palette"></use></svg>
+                  </button>
+                </div>
+
+                <div class="toolbar-group toolbar-quick" role="group" aria-label="Quick actions">
+                  <button
+                    class="btn icon"
+                    id="btnTimer"
+                    type="button"
+                    aria-label="Timer"
+                    title="Timer"
+                    aria-haspopup="dialog"
+                    aria-expanded="false"
+                    aria-pressed="false"
+                  >
+                    <svg aria-hidden="true"><use href="assets/icons.svg#timer"></use></svg>
+                  </button>
+                  <button class="btn icon" id="btnUploadPen" type="button" aria-label="Upload pen image" title="Upload pen image">
+                    <svg aria-hidden="true"><use href="assets/icons.svg#upload"></use></svg>
+                  </button>
+                  <button class="btn icon is-disabled" id="btnRemovePenImage" type="button" aria-label="Remove custom pen image" title="Remove custom pen image" disabled>
+                    <svg aria-hidden="true"><use href="assets/icons.svg#close"></use></svg>
+                  </button>
+                  <button class="btn icon" id="btnFullscreen" type="button" aria-label="Fullscreen" title="Fullscreen">
+                    <svg aria-hidden="true"><use href="assets/icons.svg#fullscreen"></use></svg>
                   </button>
                 </div>
               </div>
             </div>
 
-            <div class="toolbar-group toolbar-teach toolbar-card" role="group" aria-label="Teaching text controls">
-              <div class="teach-field">
-                <label class="teach-label" for="teachTextInput">Practice text</label>
-                <div class="teach-input-row">
-                  <input
-                    id="teachTextInput"
-                    class="teach-input"
-                    type="text"
-                    placeholder="Type a sentence for the board"
-                    autocomplete="off"
-                  />
-                  <button class="teach-button" id="btnTeach" type="button">Teach</button>
-                  <button class="teach-button" id="btnTeachNext" type="button" disabled>
-                    Next
-                    <span aria-hidden="true" class="teach-button__arrow">➜</span>
-                  </button>
+            <div class="toolbar-sections">
+              <div class="toolbar-card toolbar-lesson" role="group" aria-label="Lesson title controls">
+                <div class="lesson-title-field">
+                  <label class="lesson-title-label" for="inputLessonTitle">Lesson title</label>
+                  <div class="lesson-title-input-row">
+                    <input
+                      type="text"
+                      id="inputLessonTitle"
+                      class="lesson-title-input"
+                      placeholder="Lesson title here"
+                      autocomplete="off"
+                    />
+                    <button
+                      type="button"
+                      id="btnLessonTitleApply"
+                      class="lesson-title-apply is-disabled"
+                      disabled
+                    >
+                      Display
+                    </button>
+                  </div>
                 </div>
               </div>
-              <div class="teach-field teach-preview-block">
-                <div class="teach-preview__header">
-                  <p class="teach-label teach-preview__title">Freeze letters</p>
-                  <button
-                    type="button"
-                    id="btnToggleFreezePreview"
-                    class="teach-preview__toggle"
-                    aria-controls="teachPreview"
-                    aria-expanded="true"
-                  >
-                    Hide letters
-                  </button>
+
+              <div class="toolbar-group toolbar-teach toolbar-card" role="group" aria-label="Teaching text controls">
+                <div class="teach-field">
+                  <label class="teach-label" for="teachTextInput">Practice text</label>
+                  <div class="teach-input-row">
+                    <input
+                      id="teachTextInput"
+                      class="teach-input"
+                      type="text"
+                      placeholder="Type a sentence for the board"
+                      autocomplete="off"
+                    />
+                    <button class="teach-button" id="btnTeach" type="button">Teach</button>
+                    <button class="teach-button" id="btnTeachNext" type="button" disabled>
+                      Next
+                      <span aria-hidden="true" class="teach-button__arrow">➜</span>
+                    </button>
+                  </div>
                 </div>
-                <div class="teach-preview" id="teachPreview" aria-label="Sentence letter controls"></div>
+                <div class="teach-field teach-preview-block">
+                  <div class="teach-preview__header">
+                    <p class="teach-label teach-preview__title">Freeze letters</p>
+                    <button
+                      type="button"
+                      id="btnToggleFreezePreview"
+                      class="teach-preview__toggle"
+                      aria-controls="teachPreview"
+                      aria-expanded="true"
+                    >
+                      Hide letters
+                    </button>
+                  </div>
+                  <div class="teach-preview" id="teachPreview" aria-label="Sentence letter controls"></div>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- move the control toolbar inside the writer container, regroup controls, and swap the speed slider icon for a turtle
- restyle the board/toolbar layout for normal and fullscreen modes, hide the retro TV until a timer runs, and tighten responsive spacing
- adjust toolbar behaviour logic to drop dragging, gate collapsing to fullscreen, and recalculate fullscreen offsets using the docked layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d38c1ecfdc8331a1a96ab120440bc6