### PR TITLE
Refine control layout and resize board area

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -227,13 +227,13 @@ body {
   display: flex;
   align-items: stretch;
   justify-content: center;
-  gap: clamp(16px, 4vw, 32px);
+  gap: clamp(12px, 3vw, 24px);
   flex-wrap: wrap;
 }
 
 .board-wrapper {
   position: relative;
-  flex: 1 1 720px;
+  flex: 1 1 840px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -245,11 +245,12 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: clamp(12px, 3vw, 20px);
-  padding: clamp(12px, 2vw, 18px);
-  border-radius: 24px;
-  background: rgba(255, 244, 213, 0.25);
-  box-shadow: 0 16px 32px rgba(10, 9, 3, 0.18);
+  gap: clamp(8px, 2.2vw, 16px);
+  padding: clamp(8px, 1.8vw, 14px);
+  border-radius: 20px;
+  border: 2px solid #000000;
+  background: rgba(255, 244, 213, 0.2);
+  box-shadow: 0 14px 24px rgba(10, 9, 3, 0.16);
   backdrop-filter: blur(6px);
   flex: 0 0 auto;
 }
@@ -262,13 +263,13 @@ body {
 }
 
 .side-panel__button {
-  width: 56px;
-  height: 56px;
+  width: 52px;
+  height: 52px;
 }
 
 .side-panel__button.btn-primary {
-  width: 72px;
-  height: 72px;
+  width: 68px;
+  height: 68px;
 }
 
 .side-panel__action {
@@ -541,6 +542,24 @@ body.is-fullscreen #timerProgress {
   gap: clamp(16px, 4vw, 24px);
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   align-items: start;
+}
+
+.bottom-panel__sliders {
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(12px, 3vw, 20px);
+  align-items: center;
+  justify-content: center;
+  grid-column: 1 / -1;
+}
+
+.bottom-panel__slider {
+  flex: 1 1 clamp(220px, 28vw, 320px);
+  justify-content: center;
+}
+
+.bottom-panel__slider .slider {
+  width: min(100%, clamp(200px, 24vw, 280px));
 }
 
 .bottom-panel__practice .teach-input-row {
@@ -1301,12 +1320,13 @@ body.is-fullscreen #toolbarBottom {
     flex-direction: row;
     flex-wrap: wrap;
     justify-content: center;
-    gap: clamp(10px, 5vw, 18px);
+    gap: clamp(8px, 4vw, 16px);
+    padding: clamp(10px, 5vw, 16px);
   }
 
   .side-panel__button {
-    width: 52px;
-    height: 52px;
+    width: 48px;
+    height: 48px;
   }
 
   .side-panel__button.btn-primary {
@@ -1314,13 +1334,15 @@ body.is-fullscreen #toolbarBottom {
     height: 64px;
   }
 
-  .slider-control--stacked,
-  .slider-control--compact {
-    max-width: min(100%, 320px);
+  .bottom-panel__sliders {
+    justify-content: flex-start;
   }
 
-  .slider-control--stacked .slider,
-  .slider-control--compact .slider {
+  .bottom-panel__slider {
+    flex: 1 1 min(100%, 320px);
+  }
+
+  .bottom-panel__slider .slider {
     width: clamp(160px, 60vw, 240px);
   }
 

--- a/index.html
+++ b/index.html
@@ -178,25 +178,6 @@
             <button class="btn icon side-panel__button" id="btnRedo" type="button" aria-label="Redo" title="Redo">
               <svg aria-hidden="true"><use href="assets/icons.svg#redo"></use></svg>
             </button>
-            <div class="slider-control slider-control--stacked side-panel__slider" id="penSizeControl">
-              <span class="icon-leading" aria-hidden="true">
-                <svg><use href="assets/icons.svg#pen"></use></svg>
-              </span>
-              <label class="visually-hidden" for="sliderPenSize">Pen size</label>
-              <input
-                id="sliderPenSize"
-                class="slider"
-                type="range"
-                min="1"
-                max="40"
-                value="6"
-                step="1"
-                aria-valuemin="1"
-                aria-valuemax="40"
-                aria-valuenow="6"
-                aria-label="Pen size"
-              />
-            </div>
             <button
               class="btn icon side-panel__button"
               id="btnTimer"
@@ -275,25 +256,6 @@
             <button class="btn icon side-panel__button is-disabled" id="btnRemovePenImage" type="button" aria-label="Remove custom pen image" title="Remove custom pen image" disabled>
               <svg aria-hidden="true"><use href="assets/icons.svg#close"></use></svg>
             </button>
-            <div class="slider-control slider-control--compact side-panel__slider" id="speedControl">
-              <span class="icon-leading" aria-hidden="true">
-                <svg><use href="assets/icons.svg#turtle"></use></svg>
-              </span>
-              <label class="visually-hidden" for="sliderSpeed">Rewrite speed</label>
-              <input
-                id="sliderSpeed"
-                class="slider"
-                type="range"
-                min="0.5"
-                max="8"
-                step="0.1"
-                value="2"
-                aria-valuemin="0.5"
-                aria-valuemax="8"
-                aria-valuenow="2"
-                aria-label="Rewrite speed"
-              />
-            </div>
             <button
               class="btn icon side-panel__button"
               id="btnFullscreen"
@@ -346,6 +308,47 @@
                   autocomplete="off"
                 />
                 <button class="teach-button" id="btnTeach" type="button">Teach</button>
+              </div>
+            </div>
+
+            <div class="bottom-panel__sliders" aria-label="Drawing speed and pen size controls">
+              <div class="slider-control slider-control--stacked bottom-panel__slider" id="penSizeControl">
+                <span class="icon-leading" aria-hidden="true">
+                  <svg><use href="assets/icons.svg#pen"></use></svg>
+                </span>
+                <label class="visually-hidden" for="sliderPenSize">Pen size</label>
+                <input
+                  id="sliderPenSize"
+                  class="slider"
+                  type="range"
+                  min="1"
+                  max="40"
+                  value="6"
+                  step="1"
+                  aria-valuemin="1"
+                  aria-valuemax="40"
+                  aria-valuenow="6"
+                  aria-label="Pen size"
+                />
+              </div>
+              <div class="slider-control slider-control--compact bottom-panel__slider" id="speedControl">
+                <span class="icon-leading" aria-hidden="true">
+                  <svg><use href="assets/icons.svg#turtle"></use></svg>
+                </span>
+                <label class="visually-hidden" for="sliderSpeed">Rewrite speed</label>
+                <input
+                  id="sliderSpeed"
+                  class="slider"
+                  type="range"
+                  min="0.5"
+                  max="8"
+                  step="0.1"
+                  value="2"
+                  aria-valuemin="0.5"
+                  aria-valuemax="8"
+                  aria-valuenow="2"
+                  aria-label="Rewrite speed"
+                />
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- move the pen size and speed sliders from the side panels into the bottom toolbar for a wider drawing surface
- tighten and border the side button panels while giving the board wrapper more flex space
- add styling for the relocated sliders and adjust responsive sizing for the slimmer button panels

## Testing
- ⚠️ no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3b1b06e3c8331a23b19bb944e4441