### PR TITLE
Adjust board header styling and add zoom controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -321,13 +321,13 @@ body {
 
 .board-header {
   position: absolute;
-  top: clamp(18px, 3vw, 28px);
+  top: clamp(12px, 2.5vw, 22px);
   left: 50%;
   transform: translateX(-50%);
   display: flex;
   flex-direction: column;
-  align-items: stretch;
-  gap: 12px;
+  align-items: center;
+  gap: clamp(6px, 1.4vw, 12px);
   pointer-events: none;
   width: min(100%, 1200px);
   padding: 0 clamp(20px, 4vw, 40px);
@@ -337,20 +337,21 @@ body {
   pointer-events: auto;
   color: var(--color-smoky-black);
   font-family: 'KG Primary', 'Comic Sans MS', 'Comic Sans', cursive;
-  font-size: clamp(1.4rem, 1.6vw + 1.1rem, 2.5rem);
+  font-size: clamp(1.1rem, 1.2vw + 0.85rem, 2rem);
   text-shadow: 0.08em 0.08em rgba(255, 201, 41, 0.3);
   font-weight: 700;
   letter-spacing: 0.05em;
-  padding: 10px 16px;
-  background: rgba(255, 244, 213, 0.9);
+  padding: 8px 14px;
+  background: rgba(255, 244, 213, 0.92);
   border-radius: 14px;
   border: 2px solid rgba(10, 9, 3, 0.12);
   box-shadow: 0 6px 12px rgba(10, 9, 3, 0.18);
   cursor: pointer;
   user-select: none;
-  transition: transform 0.15s ease;
-  text-align: left;
-  align-self: flex-start;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  text-align: right;
+  align-self: flex-end;
+  margin-left: auto;
 }
 
 .board-lesson-title {
@@ -361,12 +362,33 @@ body {
   font-weight: 700;
   letter-spacing: 0.06em;
   text-shadow: 0.08em 0.08em rgba(255, 201, 41, 0.26);
-  padding: 4px 12px 6px;
+  padding: 12px clamp(20px, 6vw, 42px) 16px;
   min-height: 1.3em;
   width: 100%;
   max-width: min(100%, 820px);
   text-align: center;
   transition: opacity 0.2s ease;
+  background: rgba(255, 244, 213, 0.94);
+  border: 2px solid rgba(10, 9, 3, 0.12);
+  border-radius: 22px;
+  box-shadow: 0 20px 32px rgba(10, 9, 3, 0.2);
+  position: relative;
+  z-index: 1;
+}
+
+.board-lesson-title::before {
+  content: "";
+  position: absolute;
+  top: clamp(-28px, -3vw, -18px);
+  left: 50%;
+  transform: translateX(-50%) rotate(-2deg);
+  width: clamp(96px, 24vw, 180px);
+  height: clamp(16px, 3vw, 26px);
+  background: rgba(255, 255, 255, 0.78);
+  border-radius: 6px;
+  box-shadow: 0 10px 18px rgba(10, 9, 3, 0.18);
+  pointer-events: none;
+  z-index: 2;
 }
 
 .board-lesson-title.is-hidden {
@@ -651,6 +673,27 @@ body.is-fullscreen #timerProgress {
   filter: brightness(1.05);
 }
 
+.side-panel__action.teach-button {
+  background: #ffffff;
+  color: var(--color-smoky-black);
+  border-color: rgba(10, 9, 3, 0.18);
+  box-shadow: 0 10px 20px rgba(10, 9, 3, 0.2);
+  padding: 12px 20px;
+}
+
+.side-panel__action.teach-button:hover,
+.side-panel__action.teach-button:focus-visible {
+  background: #ffffff;
+  color: var(--color-smoky-black);
+  border-color: rgba(10, 9, 3, 0.28);
+  filter: none;
+}
+
+.side-panel__action.teach-button:active {
+  background: #ffffff;
+  color: var(--color-smoky-black);
+}
+
 .teach-button:active {
   transform: translateY(0);
   box-shadow: 0 4px 10px rgba(10, 9, 3, 0.2);
@@ -789,6 +832,29 @@ body.is-fullscreen #timerProgress {
   justify-content: center;
   gap: clamp(18px, 2.5vw, 36px);
   transform-origin: center;
+  position: relative;
+  padding: clamp(18px, 3vw, 32px) clamp(24px, 6vw, 48px);
+  background: rgba(255, 244, 213, 0.94);
+  border: 2px solid rgba(10, 9, 3, 0.12);
+  border-radius: clamp(22px, 4vw, 36px);
+  box-shadow: 0 24px 40px rgba(10, 9, 3, 0.22);
+  pointer-events: auto;
+  z-index: 1;
+}
+
+.teach-content::before {
+  content: "";
+  position: absolute;
+  top: clamp(-34px, -4vw, -20px);
+  left: 50%;
+  transform: translateX(-50%) rotate(1.6deg);
+  width: clamp(120px, 28vw, 220px);
+  height: clamp(18px, 3.2vw, 30px);
+  background: rgba(255, 255, 255, 0.78);
+  border-radius: 6px;
+  box-shadow: 0 12px 20px rgba(10, 9, 3, 0.2);
+  pointer-events: none;
+  z-index: 2;
 }
 
 .teach-line {
@@ -1449,7 +1515,7 @@ body.info-panel-open {
 
 .info-panel__close {
   border: none;
-  background: rgba(255, 255, 255, 0.75);
+  background: #ffffff;
   color: var(--color-smoky-black);
   width: 40px;
   height: 40px;
@@ -1464,7 +1530,9 @@ body.info-panel-open {
 .info-panel__close:focus-visible {
   transform: translateY(-1px);
   box-shadow: 0 18px 32px rgba(10, 9, 3, 0.2);
-  filter: brightness(1.05);
+  background: #ffffff;
+  color: var(--color-smoky-black);
+  filter: none;
 }
 
 .info-panel__close:focus-visible {

--- a/index.html
+++ b/index.html
@@ -178,6 +178,12 @@
             <button class="btn icon side-panel__button" id="btnRedo" type="button" aria-label="Redo" title="Redo">
               <svg aria-hidden="true"><use href="assets/icons.svg#redo"></use></svg>
             </button>
+            <button class="btn icon side-panel__button" id="btnZoomOut" type="button" aria-label="Zoom out" title="Zoom out">
+              <svg aria-hidden="true"><use href="assets/icons.svg#zoom-out"></use></svg>
+            </button>
+            <button class="btn icon side-panel__button" id="btnZoomIn" type="button" aria-label="Zoom in" title="Zoom in">
+              <svg aria-hidden="true"><use href="assets/icons.svg#zoom-in"></use></svg>
+            </button>
             <button
               class="btn icon side-panel__button"
               id="btnTimer"


### PR DESCRIPTION
## Summary
- reposition the board date, shrink its size, and lift the lesson title while styling both lesson and practice text as taped notes on the board
- restyle the Next button and info panel close button to a white background with dark text/icons
- add zoom in and zoom out controls to the left toolbar so existing zoom logic is available in the UI

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d3b46a8dfc83319c7f28f561b141a6