### PR TITLE
Revamp layout and controls for board interactions

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8,6 +8,8 @@
   --color-ut-orange: #ff8200;
   --color-sunglow: #ffc929;
   --color-crosstik: #fff4d5;
+  --app-fixed-width: 1440px;
+  --board-fixed-width: 1200px;
 }
 
 body {
@@ -17,6 +19,9 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: flex-start;
+  min-width: var(--app-fixed-width);
+  overflow-x: auto;
   background: var(--color-aerospace-orange);
   color: var(--color-crosstik);
   --fullscreen-toolbar-offset: 0px;
@@ -65,6 +70,38 @@ body {
   flex-direction: column;
   align-items: stretch;
   gap: clamp(18px, 4vw, 28px);
+  width: 100%;
+}
+
+.toolbar {
+  width: 100%;
+}
+
+.toolbar--top {
+  background: rgba(255, 244, 213, 0.85);
+  border-radius: 24px;
+  border: 2px solid #000000;
+  box-shadow: 0 18px 36px rgba(10, 9, 3, 0.2);
+  color: var(--color-smoky-black);
+  padding: clamp(20px, 2.6vw, 28px) clamp(24px, 3vw, 36px);
+}
+
+.toolbar-top__inner {
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(18px, 2.6vw, 28px);
+  align-items: flex-end;
+  justify-content: space-between;
+}
+
+.lesson-title-field,
+.toolbar-top__practice {
+  flex: 1 1 440px;
+  max-width: 520px;
+}
+
+.toolbar-top__practice .teach-input-row {
   width: 100%;
 }
 
@@ -122,6 +159,8 @@ body {
   color: var(--color-smoky-black);
   box-shadow: 0 10px 22px rgba(10, 9, 3, 0.18);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 .lesson-title-input:focus {
@@ -178,11 +217,21 @@ body {
 
 .main-container {
   width: 100%;
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  padding: 0;
+}
+
+.app-shell {
+  width: var(--app-fixed-width);
+  max-width: var(--app-fixed-width);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 16px;
-  padding: 0 16px 32px;
+  gap: clamp(20px, 2.4vw, 32px);
+  padding: clamp(24px, 3vw, 40px);
+  box-sizing: border-box;
 }
 
 .writer-container {
@@ -190,17 +239,17 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: clamp(24px, 5vw, 40px);
+  gap: clamp(24px, 3vw, 32px);
   touch-action: none;
   background: transparent;
   border-radius: 28px;
   border: none;
-  padding: clamp(20px, 4vw, 32px) 0;
+  padding: 0;
   box-shadow: none;
   overflow: visible;
   --zoom-level: 1;
-  width: min(100%, 1288px);
-  max-width: 1288px;
+  width: 100%;
+  max-width: 100%;
 }
 
 .writer-board {
@@ -210,7 +259,7 @@ body {
   justify-items: stretch;
   align-items: stretch;
   min-width: 0;
-  width: min(100%, 1200px);
+  width: var(--board-fixed-width);
   aspect-ratio: 2 / 1;
   border-radius: 24px;
   border: 5px solid #000000;
@@ -226,19 +275,117 @@ body {
   width: 100%;
   display: flex;
   align-items: stretch;
-  justify-content: center;
-  gap: clamp(12px, 3vw, 24px);
-  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: clamp(20px, 2.6vw, 32px);
+  flex-wrap: nowrap;
 }
 
 .board-wrapper {
   position: relative;
-  flex: 1 1 840px;
+  flex: 0 0 var(--board-fixed-width);
   display: flex;
   align-items: center;
   justify-content: center;
-  min-width: min(100%, 320px);
+  min-width: var(--board-fixed-width);
   order: 2;
+}
+
+.board-fab {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  border-radius: 22px;
+  border: 2px solid #000000;
+  background: rgba(255, 244, 213, 0.95);
+  box-shadow: 0 16px 28px rgba(10, 9, 3, 0.22);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+  z-index: 30;
+  padding: 0;
+  overflow: hidden;
+}
+
+.board-fab:hover,
+.board-fab:focus-visible {
+  transform: translateY(-50%) translateY(-2px);
+  box-shadow: 0 20px 34px rgba(10, 9, 3, 0.28);
+}
+
+.board-fab[disabled],
+.board-fab.is-disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: 0 12px 22px rgba(10, 9, 3, 0.14);
+}
+
+.board-fab[disabled]:hover,
+.board-fab[disabled]:focus-visible,
+.board-fab.is-disabled:hover,
+.board-fab.is-disabled:focus-visible {
+  transform: translateY(-50%);
+  box-shadow: 0 12px 22px rgba(10, 9, 3, 0.14);
+}
+
+.board-fab:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.65);
+  outline-offset: 3px;
+}
+
+.board-fab--undo {
+  left: clamp(20px, 2.2vw, 28px);
+  width: clamp(64px, 5vw, 72px);
+  height: clamp(64px, 5vw, 72px);
+  background: rgba(255, 244, 213, 0.92);
+}
+
+.board-fab--undo svg {
+  width: clamp(28px, 3vw, 32px);
+  height: clamp(28px, 3vw, 32px);
+}
+
+.board-fab--next {
+  right: clamp(20px, 2.2vw, 28px);
+  width: clamp(120px, 12vw, 150px);
+  min-height: clamp(128px, 13vw, 160px);
+  display: flex;
+  flex-direction: column;
+  background: transparent;
+}
+
+.board-fab__segment {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  width: 100%;
+  padding: clamp(10px, 1.8vw, 16px) clamp(12px, 2vw, 18px);
+  pointer-events: none;
+}
+
+.board-fab__segment svg {
+  width: clamp(20px, 2.4vw, 28px);
+  height: clamp(20px, 2.4vw, 28px);
+}
+
+.board-fab__segment--redo {
+  background: rgba(255, 244, 213, 0.95);
+  color: var(--color-smoky-black);
+  border-bottom: 1px solid rgba(10, 9, 3, 0.18);
+}
+
+.board-fab__segment--next {
+  background: linear-gradient(180deg, var(--color-ut-orange) 0%, var(--color-aerospace-orange) 100%);
+  color: #ffffff;
+}
+
+.board-fab__label {
+  font-weight: 700;
+  font-size: clamp(0.85rem, 0.9vw, 1rem);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .side-panel {
@@ -544,49 +691,63 @@ body.is-fullscreen #timerProgress {
 #toolbarBottom {
   position: relative;
   display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: clamp(16px, 4vw, 28px);
-  width: min(var(--board-width, 1200px), 100%);
-  margin: clamp(20px, 5vw, 36px) auto 0;
-  background: rgba(255, 255, 255, 0.92);
-  border-radius: 28px;
-  box-shadow: 0 16px 32px rgba(10, 9, 3, 0.2);
-  border: none;
-  color: var(--color-smoky-black);
-  z-index: 20;
-  padding: clamp(20px, 5vw, 32px);
-  transition: box-shadow 0.3s ease, transform 0.3s ease;
-}
-
-.bottom-panel__inner {
-  display: grid;
-  gap: clamp(16px, 4vw, 24px);
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  align-items: start;
-}
-
-.bottom-panel__sliders {
-  display: flex;
-  flex-wrap: wrap;
-  gap: clamp(12px, 3vw, 20px);
   align-items: center;
   justify-content: center;
-  grid-column: 1 / -1;
+  width: min(var(--board-width, var(--board-fixed-width)), 100%);
+  margin: clamp(8px, 1.8vw, 16px) auto 0;
+  background: rgba(255, 244, 213, 0.2);
+  border-radius: 24px;
+  border: 2px solid #000000;
+  box-shadow: 0 14px 24px rgba(10, 9, 3, 0.16);
+  backdrop-filter: blur(6px);
+  color: var(--color-smoky-black);
+  padding: clamp(16px, 2.6vw, 24px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  z-index: 20;
 }
 
-.bottom-panel__slider {
-  flex: 1 1 clamp(220px, 28vw, 320px);
-  justify-content: center;
+body.board-controls-hidden .side-panel,
+body.board-controls-hidden #toolbarBottom {
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(12px);
 }
 
-.bottom-panel__slider .slider {
-  width: min(100%, clamp(200px, 24vw, 280px));
-}
-
-.bottom-panel__practice .teach-input-row {
+.bottom-toolbar__inner {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: clamp(16px, 2.4vw, 24px);
+}
+
+.bottom-toolbar__sliders {
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(12px, 2vw, 20px);
+  align-items: center;
+  justify-content: center;
+  flex: 1 1 520px;
+}
+
+.bottom-toolbar__slider {
+  flex: 1 1 clamp(220px, 24vw, 320px);
+  justify-content: center;
+  max-width: 320px;
+}
+
+.bottom-toolbar__slider .slider {
+  width: 100%;
+}
+
+.bottom-toolbar__play {
+  width: clamp(68px, 5vw, 82px);
+  height: clamp(68px, 5vw, 82px);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 10px 22px rgba(10, 9, 3, 0.2);
 }
 
 #toolbarBottom.is-fullscreen-active {
@@ -1400,15 +1561,15 @@ body.is-fullscreen #toolbarBottom {
     height: 64px;
   }
 
-  .bottom-panel__sliders {
+  .bottom-toolbar__sliders {
     justify-content: flex-start;
   }
 
-  .bottom-panel__slider {
+  .bottom-toolbar__slider {
     flex: 1 1 min(100%, 320px);
   }
 
-  .bottom-panel__slider .slider {
+  .bottom-toolbar__slider .slider {
     width: clamp(160px, 60vw, 240px);
   }
 
@@ -1426,8 +1587,8 @@ body.is-fullscreen #toolbarBottom {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: clamp(48px, 5.5vw, 56px);
-  height: clamp(48px, 5.5vw, 56px);
+  gap: clamp(8px, 1.2vw, 12px);
+  padding: clamp(10px, 1.8vw, 14px) clamp(16px, 2.6vw, 22px);
   border-radius: 999px;
   border: 2px solid rgba(10, 9, 3, 0.18);
   background: linear-gradient(180deg, rgba(255, 244, 213, 0.96) 0%, rgba(255, 201, 41, 0.96) 100%);
@@ -1458,6 +1619,12 @@ body.is-fullscreen #toolbarBottom {
 .info-panel-toggle__icon {
   font-size: clamp(1.4rem, 2.4vw, 1.6rem);
   font-family: "Comic Sans MS", "KG Primary", "Chalkboard SE", "Comic Neue", cursive;
+}
+
+.info-panel-toggle__label {
+  font-size: clamp(0.9rem, 1.1vw, 1.05rem);
+  font-weight: 700;
+  text-transform: uppercase;
 }
 
 .info-panel-backdrop {
@@ -1657,17 +1824,9 @@ body.info-panel-open {
     padding: clamp(20px, 8vw, 28px);
   }
 
-  .bottom-panel__inner {
-    grid-template-columns: 1fr;
-  }
-
-  .bottom-panel__practice .teach-input-row {
+  .bottom-toolbar__inner {
     flex-direction: column;
     align-items: stretch;
-  }
-
-  .bottom-panel__practice .teach-button {
-    width: 100%;
   }
 
   .side-panel {

--- a/index.html
+++ b/index.html
@@ -3,20 +3,20 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Master handwriting</title>
+    <title>Teach Handwriting</title>
     <meta
       name="description"
-      content="Handwriting Repeater is an interactive handwriting practice tool with looping playback, tracing guides, and adjustable pen settings to help learners master letter formation."
+      content="Teach Handwriting is an interactive handwriting practice tool with looping playback, tracing guides, and adjustable pen settings to help learners master letter formation."
     />
     <meta
       name="keywords"
       content="handwriting practice, handwriting repeater, tracing letters, handwriting tool, education technology"
     />
     <meta name="robots" content="index, follow" />
-    <meta name="author" content="Handwriting Repeater" />
+    <meta name="author" content="Teach Handwriting" />
     <link rel="canonical" href="https://handwritingrepeater.app/" />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Handwriting Repeater" />
+    <meta property="og:title" content="Teach Handwriting" />
     <meta
       property="og:description"
       content="Demonstrate perfect penmanship with looping handwriting playback, tracing overlays, and customizable pen tools."
@@ -24,7 +24,7 @@
     <meta property="og:url" content="https://handwritingrepeater.app/" />
     <meta property="og:image" content="https://handwritingrepeater.app/images/social-share.png" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Handwriting Repeater" />
+    <meta name="twitter:title" content="Teach Handwriting" />
     <meta
       name="twitter:description"
       content="Interactive handwriting demonstrator with auto-repeat playback, tracing guides, and adjustable pens for classrooms and home learning."
@@ -45,7 +45,7 @@
       {
         "@context": "https://schema.org",
         "@type": "WebApplication",
-        "name": "Handwriting Repeater",
+        "name": "Teach Handwriting",
         "url": "https://handwritingrepeater.app/",
         "description": "Interactive handwriting teaching app with looping playback, tracing overlays, and customizable drawing tools.",
         "applicationCategory": "EducationApplication",
@@ -66,10 +66,11 @@
       aria-haspopup="dialog"
       aria-expanded="false"
       aria-controls="infoPanel"
-      title="About Handwriting Repeater and feedback"
+      aria-label="Teach Handwriting information and feedback"
+      title="Teach Handwriting information and feedback"
     >
-      <span class="visually-hidden">About Handwriting Repeater and feedback</span>
       <span aria-hidden="true" class="info-panel-toggle__icon">i</span>
+      <span class="info-panel-toggle__label">Teach Handwriting</span>
     </button>
 
     <div id="infoPanelBackdrop" class="info-panel-backdrop" hidden></div>
@@ -84,7 +85,7 @@
       tabindex="-1"
     >
       <div class="info-panel__header">
-        <h2 class="info-panel__title" id="infoPanelTitle">Handwriting Repeater</h2>
+        <h2 class="info-panel__title" id="infoPanelTitle">Teach Handwriting</h2>
         <button
           type="button"
           class="info-panel__close"
@@ -97,9 +98,9 @@
 
       <div class="info-panel__content">
         <section class="info-panel__section" aria-labelledby="infoPanelAboutHeading">
-          <h3 class="info-panel__section-title" id="infoPanelAboutHeading">About Handwriting Repeater</h3>
+          <h3 class="info-panel__section-title" id="infoPanelAboutHeading">About Teach Handwriting</h3>
           <p class="info-panel__text">
-            Handwriting Repeater is a browser-based handwriting demonstrator designed for classrooms, tutoring sessions, and
+            Teach Handwriting is a browser-based handwriting demonstrator designed for classrooms, tutoring sessions, and
             home learning. Educators can record handwriting strokes once and loop the playback so students can focus on
             correct letter formation without constant repetition.
           </p>
@@ -113,7 +114,7 @@
         <section class="info-panel__section" aria-labelledby="infoPanelFeedbackHeading">
           <h3 class="info-panel__section-title" id="infoPanelFeedbackHeading">Send Feedback</h3>
           <p class="info-panel__section-intro">
-            Have suggestions or want to share how you use Handwriting Repeater? Drop a quick note below and we&rsquo;ll get back
+            Have suggestions or want to share how you use Teach Handwriting? Drop a quick note below and we&rsquo;ll get back
             to you.
           </p>
           <form
@@ -162,126 +163,15 @@
       </div>
     </section>
 
-    <header class="title-container" role="banner">
-      <div class="title-texts">
-        <h1 class="title-text">Master handwriting</h1>
-      </div>
-    </header>
-
-    <main class="main-container disable-select" role="main">
-      <div id="writerContainer" class="writer-container">
-        <div class="board-layout">
-          <aside class="side-panel side-panel--left" aria-label="Drawing controls">
-            <button class="btn icon side-panel__button" id="btnUndo" type="button" aria-label="Undo" title="Undo">
-              <svg aria-hidden="true"><use href="assets/icons.svg#undo"></use></svg>
-            </button>
-            <button class="btn icon side-panel__button" id="btnRedo" type="button" aria-label="Redo" title="Redo">
-              <svg aria-hidden="true"><use href="assets/icons.svg#redo"></use></svg>
-            </button>
-            <button class="btn icon side-panel__button" id="btnZoomOut" type="button" aria-label="Zoom out" title="Zoom out">
-              <svg aria-hidden="true"><use href="assets/icons.svg#zoom-out"></use></svg>
-            </button>
-            <button class="btn icon side-panel__button" id="btnZoomIn" type="button" aria-label="Zoom in" title="Zoom in">
-              <svg aria-hidden="true"><use href="assets/icons.svg#zoom-in"></use></svg>
-            </button>
-            <button
-              class="btn icon side-panel__button"
-              id="btnTimer"
-              type="button"
-              aria-label="Timer"
-              title="Timer"
-              aria-haspopup="dialog"
-              aria-expanded="false"
-              aria-pressed="false"
-            >
-              <svg aria-hidden="true"><use href="assets/icons.svg#timer"></use></svg>
-            </button>
-            <button
-              class="btn icon side-panel__button"
-              id="btnFullscreenLeft"
-              type="button"
-              data-action="fullscreen"
-              aria-label="Fullscreen"
-              title="Fullscreen"
-            >
-              <svg aria-hidden="true"><use href="assets/icons.svg#fullscreen"></use></svg>
-            </button>
-          </aside>
-
-          <div class="board-wrapper">
-            <div id="writerBoard" class="writer-board">
-              <canvas id="writerPage" width="1200" height="600"></canvas>
-              <canvas id="writerTrace" width="1200" height="600"></canvas>
-              <canvas id="writerLines" width="1200" height="600"></canvas>
-              <canvas id="writer" width="1200" height="600"></canvas>
-              <canvas id="writerMask" width="1200" height="600"></canvas>
-              <div id="teachOverlay" class="teach-overlay" aria-live="polite"></div>
-            </div>
-
-            <div id="boardHeader" class="board-header">
-              <div id="boardDate" aria-label="Date" role="button" tabindex="0">Loading date…</div>
-              <div
-                id="boardLessonTitle"
-                class="board-lesson-title is-hidden"
-                aria-live="polite"
-                aria-hidden="true"
-              ></div>
-            </div>
-            <div id="retroTv" class="tv-off" aria-hidden="true">
-              <div class="tv-frame">
-                <div id="tvPlayer" class="tv-screen" title="Retro TV" role="presentation"></div>
-                <div class="tv-overlay" aria-hidden="true"></div>
-              </div>
-            </div>
-
-            <div id="timerProgress" aria-hidden="true"></div>
-          </div>
-
-          <aside class="side-panel side-panel--right" aria-label="Playback controls">
-            <button class="teach-button side-panel__action" id="btnTeachNext" type="button" disabled>
-              Next
-              <span aria-hidden="true" class="teach-button__arrow">➜</span>
-            </button>
-            <button
-              class="btn icon side-panel__button"
-              id="btnPalette"
-              type="button"
-              aria-label="Pen colour"
-              title="Pen colour"
-              aria-haspopup="dialog"
-              aria-expanded="false"
-            >
-              <svg aria-hidden="true"><use href="assets/icons.svg#palette"></use></svg>
-            </button>
-            <button class="btn icon btn-primary side-panel__button" id="btnRewrite" type="button" aria-label="Rewrite" title="Rewrite" aria-pressed="false">
-              <svg aria-hidden="true"><use href="assets/icons.svg#play"></use></svg>
-            </button>
-            <button class="btn icon side-panel__button" id="btnUploadPen" type="button" aria-label="Upload pen image" title="Upload pen image">
-              <svg aria-hidden="true"><use href="assets/icons.svg#upload"></use></svg>
-            </button>
-            <button class="btn icon side-panel__button is-disabled" id="btnRemovePenImage" type="button" aria-label="Remove custom pen image" title="Remove custom pen image" disabled>
-              <svg aria-hidden="true"><use href="assets/icons.svg#close"></use></svg>
-            </button>
-            <button
-              class="btn icon side-panel__button"
-              id="btnFullscreen"
-              type="button"
-              data-action="fullscreen"
-              aria-label="Fullscreen"
-              title="Fullscreen"
-            >
-              <svg aria-hidden="true"><use href="assets/icons.svg#fullscreen"></use></svg>
-            </button>
-          </aside>
-        </div>
-
-        <div
-          id="toolbarBottom"
+    <main class="main-container" role="main">
+      <div class="app-shell disable-select">
+        <section
+          id="toolbarTop"
+          class="toolbar toolbar--top"
           role="region"
           aria-label="Lesson and practice settings"
-          class="disable-select"
         >
-          <div class="bottom-panel__inner">
+          <div class="toolbar-top__inner">
             <div class="lesson-title-field">
               <label class="lesson-title-label" for="inputLessonTitle">Lesson title</label>
               <div class="lesson-title-input-row">
@@ -303,7 +193,7 @@
               </div>
             </div>
 
-            <div class="teach-field bottom-panel__practice">
+            <div class="teach-field toolbar-top__practice">
               <label class="teach-label" for="teachTextInput">Practice text</label>
               <div class="teach-input-row">
                 <input
@@ -316,9 +206,134 @@
                 <button class="teach-button" id="btnTeach" type="button">Teach</button>
               </div>
             </div>
+          </div>
+        </section>
 
-            <div class="bottom-panel__sliders" aria-label="Drawing speed and pen size controls">
-              <div class="slider-control slider-control--stacked bottom-panel__slider" id="penSizeControl">
+        <div id="writerContainer" class="writer-container">
+          <div class="board-layout">
+            <aside class="side-panel side-panel--left" aria-label="Drawing controls">
+              <button class="btn icon side-panel__button" id="btnZoomOut" type="button" aria-label="Zoom out" title="Zoom out">
+                <svg aria-hidden="true"><use href="assets/icons.svg#zoom-out"></use></svg>
+              </button>
+              <button class="btn icon side-panel__button" id="btnZoomIn" type="button" aria-label="Zoom in" title="Zoom in">
+                <svg aria-hidden="true"><use href="assets/icons.svg#zoom-in"></use></svg>
+              </button>
+              <button
+                class="btn icon side-panel__button"
+                id="btnTimer"
+                type="button"
+                aria-label="Timer"
+                title="Timer"
+                aria-haspopup="dialog"
+                aria-expanded="false"
+                aria-pressed="false"
+              >
+                <svg aria-hidden="true"><use href="assets/icons.svg#timer"></use></svg>
+              </button>
+              <button
+                class="btn icon side-panel__button"
+                id="btnFullscreenLeft"
+                type="button"
+                data-action="fullscreen"
+                aria-label="Fullscreen"
+                title="Fullscreen"
+              >
+                <svg aria-hidden="true"><use href="assets/icons.svg#fullscreen"></use></svg>
+              </button>
+            </aside>
+
+            <div class="board-wrapper">
+              <div id="writerBoard" class="writer-board">
+                <canvas id="writerPage" width="1200" height="600"></canvas>
+                <canvas id="writerTrace" width="1200" height="600"></canvas>
+                <canvas id="writerLines" width="1200" height="600"></canvas>
+                <canvas id="writer" width="1200" height="600"></canvas>
+                <canvas id="writerMask" width="1200" height="600"></canvas>
+                <div id="teachOverlay" class="teach-overlay" aria-live="polite"></div>
+              </div>
+
+              <div id="boardHeader" class="board-header">
+                <div id="boardDate" aria-label="Date" role="button" tabindex="0">Loading date…</div>
+                <div
+                  id="boardLessonTitle"
+                  class="board-lesson-title is-hidden"
+                  aria-live="polite"
+                  aria-hidden="true"
+                ></div>
+              </div>
+              <div id="retroTv" class="tv-off" aria-hidden="true">
+                <div class="tv-frame">
+                  <div id="tvPlayer" class="tv-screen" title="Retro TV" role="presentation"></div>
+                  <div class="tv-overlay" aria-hidden="true"></div>
+                </div>
+              </div>
+
+              <div id="timerProgress" aria-hidden="true"></div>
+
+              <button class="board-fab board-fab--undo" id="btnUndo" type="button" aria-label="Undo" title="Undo">
+                <svg aria-hidden="true"><use href="assets/icons.svg#undo"></use></svg>
+              </button>
+
+              <button
+                class="board-fab board-fab--next"
+                id="btnTeachNext"
+                type="button"
+                aria-label="Redo (top) or Next (bottom)"
+                title="Tap top for redo, bottom for next"
+                disabled
+              >
+                <span class="board-fab__segment board-fab__segment--redo" aria-hidden="true">
+                  <svg aria-hidden="true"><use href="assets/icons.svg#redo"></use></svg>
+                  <span class="board-fab__label">Redo</span>
+                </span>
+                <span class="board-fab__segment board-fab__segment--next">
+                  <span class="board-fab__label">Next</span>
+                  <span aria-hidden="true" class="teach-button__arrow">➜</span>
+                </span>
+              </button>
+            </div>
+
+            <aside class="side-panel side-panel--right" aria-label="Playback controls">
+              <button
+                class="btn icon side-panel__button"
+                id="btnPalette"
+                type="button"
+                aria-label="Pen colour"
+                title="Pen colour"
+                aria-haspopup="dialog"
+                aria-expanded="false"
+              >
+                <svg aria-hidden="true"><use href="assets/icons.svg#palette"></use></svg>
+              </button>
+              <button class="btn icon side-panel__button" id="btnUploadPen" type="button" aria-label="Upload pen image" title="Upload pen image">
+                <svg aria-hidden="true"><use href="assets/icons.svg#upload"></use></svg>
+              </button>
+              <button class="btn icon side-panel__button is-disabled" id="btnRemovePenImage" type="button" aria-label="Remove custom pen image" title="Remove custom pen image" disabled>
+                <svg aria-hidden="true"><use href="assets/icons.svg#close"></use></svg>
+              </button>
+              <button
+                class="btn icon side-panel__button"
+                id="btnFullscreen"
+                type="button"
+                data-action="fullscreen"
+                aria-label="Fullscreen"
+                title="Fullscreen"
+              >
+                <svg aria-hidden="true"><use href="assets/icons.svg#fullscreen"></use></svg>
+              </button>
+            </aside>
+          </div>
+        </div>
+
+        <section
+          id="toolbarBottom"
+          class="toolbar toolbar--bottom"
+          role="region"
+          aria-label="Drawing speed and playback controls"
+        >
+          <div class="bottom-toolbar__inner">
+            <div class="bottom-toolbar__sliders" aria-label="Drawing speed and pen size controls">
+              <div class="slider-control slider-control--stacked bottom-toolbar__slider" id="penSizeControl">
                 <span class="icon-leading" aria-hidden="true">
                   <svg><use href="assets/icons.svg#pen"></use></svg>
                 </span>
@@ -337,7 +352,7 @@
                   aria-label="Pen size"
                 />
               </div>
-              <div class="slider-control slider-control--compact bottom-panel__slider" id="speedControl">
+              <div class="slider-control slider-control--compact bottom-toolbar__slider" id="speedControl">
                 <span class="icon-leading" aria-hidden="true">
                   <svg><use href="assets/icons.svg#turtle"></use></svg>
                 </span>
@@ -357,8 +372,11 @@
                 />
               </div>
             </div>
+            <button class="btn icon btn-primary bottom-toolbar__play" id="btnRewrite" type="button" aria-label="Rewrite" title="Rewrite" aria-pressed="false">
+              <svg aria-hidden="true"><use href="assets/icons.svg#play"></use></svg>
+            </button>
           </div>
-        </div>
+        </section>
       </div>
     </main>
 

--- a/js/teach.js
+++ b/js/teach.js
@@ -6,13 +6,22 @@ const LETTER_COLLATOR =
     : null;
 
 export class TeachController {
-  constructor({ overlay, textInput, teachButton, nextButton, previewContainer, previewToggleButton }) {
+  constructor({
+    overlay,
+    textInput,
+    teachButton,
+    nextButton,
+    previewContainer,
+    previewToggleButton,
+    enableDefaultNextHandler = true
+  }) {
     this.overlay = overlay ?? null;
     this.textInput = textInput ?? null;
     this.teachButton = teachButton ?? null;
     this.nextButton = nextButton ?? null;
     this.previewContainer = previewContainer ?? null;
     this.previewToggleButton = previewToggleButton ?? null;
+    this.enableDefaultNextHandler = enableDefaultNextHandler;
 
     this.overlayContent = null;
     this.lines = [];
@@ -28,7 +37,9 @@ export class TeachController {
     this.handleTogglePreview = this.handleTogglePreview.bind(this);
 
     this.teachButton?.addEventListener('click', this.handleTeach);
-    this.nextButton?.addEventListener('click', this.handleNext);
+    if (this.nextButton && this.enableDefaultNextHandler) {
+      this.nextButton.addEventListener('click', this.handleNext);
+    }
     this.previewContainer?.addEventListener('click', this.handlePreviewClick);
     this.previewToggleButton?.addEventListener('click', this.handleTogglePreview);
     this.textInput?.addEventListener('keydown', event => {


### PR DESCRIPTION
## Summary
- remove the legacy header and move lesson/practice controls into a fixed-width top toolbar with updated branding
- relocate undo/next controls inside the board, combine next/redo interactions in a split button, and move playback sliders/play control to a matching bottom bar that hides alongside side panels while writing
- add board interaction logic to hide/show peripheral controls, update styles for fixed app layout, and allow the info toggle to display the new Teach Handwriting title

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3c1a592f08331b958dc4b6bb09395