### PR TITLE
Refine board layout and controls

### DIFF
--- a/assets/icons.svg
+++ b/assets/icons.svg
@@ -52,6 +52,10 @@
     <path d="M9 7V5.5A1.5 1.5 0 0 1 10.5 4h3A1.5 1.5 0 0 1 15 5.5V7" fill="none" stroke="currentColor" stroke-width="2" />
     <path d="M8 7l.7 11a1.5 1.5 0 0 0 1.5 1.4h3.6a1.5 1.5 0 0 0 1.5-1.4L16 7" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" />
   </symbol>
+  <symbol id="page-blank" viewBox="0 0 24 24">
+    <path d="M6 3h9l5 5v13H6a3 3 0 0 1-3-3V6a3 3 0 0 1 3-3z" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" />
+    <polyline points="15 3 15 9 21 9" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" />
+  </symbol>
   <symbol id="page-lines" viewBox="0 0 24 24">
     <rect x="4" y="5" width="16" height="14" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="2" />
     <line x1="7" y1="9" x2="17" y2="9" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />

--- a/css/style.css
+++ b/css/style.css
@@ -174,45 +174,16 @@ body {
 }
 
 .lesson-title-apply {
-  padding: 12px 18px;
-  border-radius: 12px;
-  border: 2px solid rgba(10, 9, 3, 0.16);
-  background: linear-gradient(180deg, rgba(255, 130, 0, 0.96) 0%, rgba(255, 201, 41, 0.96) 100%);
-  color: var(--color-smoky-black);
-  font-weight: 600;
-  letter-spacing: 0.04em;
   text-transform: uppercase;
-  font-size: 0.95rem;
-  box-shadow: 0 10px 22px rgba(10, 9, 3, 0.18);
-  cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
+  letter-spacing: 0.04em;
   min-width: 108px;
-}
-
-.lesson-title-apply:hover,
-.lesson-title-apply:focus-visible {
-  box-shadow: 0 14px 28px rgba(10, 9, 3, 0.22);
-  transform: translateY(-1px);
-  filter: brightness(1.05);
-}
-
-.lesson-title-apply:focus-visible {
-  outline: 3px solid rgba(255, 255, 255, 0.6);
-  outline-offset: 3px;
-}
-
-.lesson-title-apply:active {
-  transform: translateY(0);
-  box-shadow: 0 8px 18px rgba(10, 9, 3, 0.2);
 }
 
 .lesson-title-apply.is-disabled,
 .lesson-title-apply:disabled {
   cursor: not-allowed;
   opacity: 0.6;
-  box-shadow: none;
-  transform: none;
-  filter: grayscale(0.1);
+  filter: grayscale(0.2);
 }
 
 .main-container {
@@ -252,6 +223,17 @@ body {
   max-width: 100%;
 }
 
+.board-frame {
+  position: relative;
+  flex: 0 0 var(--board-fixed-width);
+  width: var(--board-fixed-width);
+  border-radius: 28px;
+  border: 5px solid #000000;
+  background: #ffffff;
+  box-shadow: 0 22px 44px rgba(10, 9, 3, 0.24);
+  overflow: hidden;
+}
+
 .writer-board {
   position: relative;
   display: grid;
@@ -259,16 +241,26 @@ body {
   justify-items: stretch;
   align-items: stretch;
   min-width: 0;
-  width: var(--board-fixed-width);
+  width: 100%;
   aspect-ratio: 2 / 1;
-  border-radius: 24px;
-  border: 5px solid #000000;
-  background: #ffffff;
-  box-shadow: 0 22px 44px rgba(10, 9, 3, 0.24);
   overflow: hidden;
+  background: transparent;
+  border-radius: inherit;
+}
+
+.writer-board__content {
+  grid-row: 1;
+  grid-column: 1;
+  display: grid;
+  grid-template-columns: 1fr;
+  justify-items: stretch;
+  align-items: stretch;
+  width: 100%;
+  height: 100%;
   transform: scale(var(--zoom-level, 1));
   transform-origin: top center;
   will-change: transform;
+  border-radius: inherit;
 }
 
 .board-layout {
@@ -414,6 +406,13 @@ body {
   height: 52px;
 }
 
+.side-panel__button.is-active {
+  background: #ffffff;
+  color: var(--color-smoky-black);
+  border-color: rgba(10, 9, 3, 0.28);
+  box-shadow: 0 14px 28px rgba(10, 9, 3, 0.22);
+}
+
 .side-panel__button.btn-primary {
   width: 68px;
   height: 68px;
@@ -446,7 +445,7 @@ body {
   width: clamp(120px, 18vw, 180px);
 }
 
-.writer-board canvas {
+.writer-board__content canvas {
   grid-row: 1;
   grid-column: 1;
   width: 100%;
@@ -467,19 +466,21 @@ body {
 }
 
 
+.board-region {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(16px, 3vw, 28px);
+  width: 100%;
+}
+
 .board-header {
-  position: absolute;
-  top: clamp(12px, 2.5vw, 22px);
-  left: 0;
-  right: 0;
-  transform: none;
+  width: min(100%, var(--board-fixed-width));
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: clamp(12px, 3vw, 36px);
-  pointer-events: none;
-  width: 100%;
-  padding: 0 clamp(24px, 4vw, 44px);
+  gap: clamp(12px, 2.6vw, 36px);
+  padding: 0 clamp(8px, 2vw, 24px);
   box-sizing: border-box;
 }
 
@@ -487,17 +488,16 @@ body {
 .board-header__date {
   display: flex;
   align-items: flex-start;
-  pointer-events: none;
+  flex: 1 1 0;
+  min-width: 0;
 }
 
 .board-header__title {
-  flex: 1 1 clamp(260px, 56%, 640px);
-  max-width: clamp(260px, 56%, 640px);
+  max-width: 100%;
 }
 
 .board-header__date {
-  flex: 0 1 clamp(180px, 30%, 340px);
-  max-width: clamp(180px, 30%, 340px);
+  flex: 0 1 clamp(180px, 32%, 320px);
   justify-content: flex-end;
 }
 
@@ -506,64 +506,49 @@ body {
   color: var(--color-smoky-black);
   font-family: 'KG Primary', 'Comic Sans MS', 'Comic Sans', cursive;
   font-size: clamp(1.1rem, 1.2vw + 0.85rem, 2rem);
-  text-shadow: 0.08em 0.08em rgba(255, 201, 41, 0.3);
   font-weight: 700;
   letter-spacing: 0.05em;
-  padding: 8px 14px;
-  background: rgba(255, 244, 213, 0.92);
-  border-radius: 14px;
-  border: 2px solid rgba(10, 9, 3, 0.12);
-  box-shadow: 0 6px 12px rgba(10, 9, 3, 0.18);
+  padding: 4px 0;
+  text-shadow: none;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
   cursor: pointer;
   user-select: none;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  transition: color 0.15s ease;
   text-align: right;
-  flex: 0 1 100%;
-  max-width: 100%;
-}
-
-.board-lesson-title {
-  pointer-events: none;
-  color: var(--color-ut-orange);
-  font-family: 'KG Primary', 'Comic Sans MS', 'Comic Sans', cursive;
-  font-size: clamp(2rem, 2vw + 1.35rem, 3.2rem);
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-shadow: 0.08em 0.08em rgba(255, 201, 41, 0.18);
-  padding: 12px clamp(18px, 5vw, 36px) 16px;
-  min-height: 1.3em;
-  width: 100%;
-  max-width: 100%;
-  text-align: left;
-  transition: opacity 0.2s ease;
-  background: rgba(255, 244, 213, 0.94);
-  border: 2px solid rgba(10, 9, 3, 0.12);
-  border-radius: 22px;
-  box-shadow: 0 20px 32px rgba(10, 9, 3, 0.2);
-  position: relative;
-  z-index: 1;
-}
-
-.board-lesson-title::before {
-  display: none;
-}
-
-.board-lesson-title.is-hidden {
-  opacity: 0;
 }
 
 #boardDate:hover,
 #boardDate:focus-visible {
-  transform: translateY(-2px);
+  color: var(--color-ut-orange);
   outline: none;
-  box-shadow: 0 10px 18px rgba(10, 9, 3, 0.2);
-  background: #ffffff;
+  transform: none;
 }
 
 #boardDate:active {
-  transform: translateY(0);
-  background: rgba(255, 244, 213, 0.9);
-  box-shadow: 0 4px 8px rgba(10, 9, 3, 0.24);
+  color: var(--color-aerospace-orange);
+}
+
+.board-lesson-title {
+  pointer-events: none;
+  color: var(--color-smoky-black);
+  font-family: 'KG Primary', 'Comic Sans MS', 'Comic Sans', cursive;
+  font-size: clamp(2rem, 2vw + 1.35rem, 3.1rem);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-shadow: none;
+  padding: 0;
+  min-height: 1.2em;
+  width: 100%;
+  max-width: 100%;
+  text-align: left;
+  transition: opacity 0.2s ease;
+}
+
+.board-lesson-title.is-hidden {
+  opacity: 0;
 }
 
 body.is-fullscreen {
@@ -602,13 +587,16 @@ body.is-fullscreen .writer-container {
   box-sizing: border-box;
 }
 
-body.is-fullscreen .writer-board {
+body.is-fullscreen .board-frame {
   width: min(100vw, calc((100vh - var(--fullscreen-toolbar-offset, 0px)) * 2));
   max-width: none;
   border-radius: 0;
-  border: none;
   box-shadow: none;
   margin: 0 auto;
+}
+
+body.is-fullscreen .writer-board {
+  width: 100%;
 }
 
 body.is-fullscreen .board-header {
@@ -734,38 +722,101 @@ body.board-controls-hidden #toolbarBottom {
 .bottom-toolbar__inner {
   width: 100%;
   display: flex;
+  align-items: stretch;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: clamp(16px, 2.8vw, 28px);
+}
+
+.control-popover {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  flex: 0 1 clamp(220px, 28vw, 360px);
+}
+
+.control-popover__toggle {
+  display: flex;
   align-items: center;
   justify-content: space-between;
-  flex-wrap: wrap;
-  gap: clamp(16px, 2.4vw, 24px);
+  gap: 12px;
+  padding: 12px 18px;
+  border-radius: 999px;
+  border: 2px solid rgba(10, 9, 3, 0.16);
+  background: #ffffff;
+  color: var(--color-smoky-black);
+  font-family: inherit;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  box-shadow: 0 12px 24px rgba(10, 9, 3, 0.18);
+  transition: transform 0.12s ease, box-shadow 0.12s ease, border-color 0.12s ease;
 }
 
-.bottom-toolbar__sliders {
-  display: flex;
-  flex-wrap: wrap;
-  gap: clamp(12px, 2vw, 20px);
-  align-items: center;
-  justify-content: center;
-  flex: 1 1 520px;
+.control-popover__toggle:hover,
+.control-popover__toggle:focus-visible,
+.control-popover.is-open .control-popover__toggle {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 28px rgba(10, 9, 3, 0.22);
+  border-color: rgba(10, 9, 3, 0.28);
+  outline: none;
 }
 
-.bottom-toolbar__slider {
-  flex: 1 1 clamp(220px, 24vw, 320px);
-  justify-content: center;
-  max-width: 320px;
-}
-
-.bottom-toolbar__slider .slider {
-  width: 100%;
-}
-
-.bottom-toolbar__play {
-  width: clamp(68px, 5vw, 82px);
-  height: clamp(68px, 5vw, 82px);
+.control-popover__icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 10px 22px rgba(10, 9, 3, 0.2);
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(255, 244, 213, 0.9);
+  color: var(--color-smoky-black);
+  flex: 0 0 auto;
+}
+
+.control-popover__icon svg {
+  width: 20px;
+  height: 20px;
+}
+
+.control-popover__label {
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.control-popover__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--color-ut-orange);
+}
+
+.control-popover__panel {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 12px);
+  transform: translateX(-50%);
+  padding: 14px 18px;
+  border-radius: 18px;
+  border: 2px solid rgba(10, 9, 3, 0.12);
+  background: rgba(255, 244, 213, 0.95);
+  box-shadow: 0 18px 32px rgba(10, 9, 3, 0.22);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: clamp(220px, 28vw, 320px);
+  z-index: 5;
+}
+
+.control-popover__panel .slider {
+  width: 100%;
+}
+
+.control-popover__panel[hidden] {
+  display: none;
 }
 
 #toolbarBottom.is-fullscreen-active {
@@ -947,8 +998,8 @@ body.board-controls-hidden #toolbarBottom {
   min-height: 28px;
   padding: 6px 8px;
   border-radius: 10px;
-  border: 1px solid rgba(10, 9, 3, 0.12);
-  background: rgba(255, 255, 255, 0.85);
+  border: none;
+  background: transparent;
   font-size: 1.1rem;
   font-family: "KG Primary", "Comic Sans MS", "Comic Sans", cursive;
   color: var(--color-smoky-black);
@@ -957,6 +1008,7 @@ body.board-controls-hidden #toolbarBottom {
   justify-content: center;
   cursor: pointer;
   transition: transform 0.12s ease, box-shadow 0.12s ease;
+  box-shadow: none;
   appearance: none;
 }
 
@@ -974,12 +1026,12 @@ body.board-controls-hidden #toolbarBottom {
 }
 
 .teach-preview__letter.is-revealed {
-  background: rgba(255, 244, 213, 0.95);
+  background: transparent;
+  box-shadow: none;
 }
 
 .teach-preview__letter.is-frozen {
-  border-color: var(--color-ut-orange);
-  box-shadow: 0 0 0 2px rgba(255, 130, 0, 0.2);
+  box-shadow: 0 0 0 2px rgba(255, 130, 0, 0.25);
 }
 
 .teach-preview__letter[disabled] {
@@ -1013,27 +1065,16 @@ body.board-controls-hidden #toolbarBottom {
   transform-origin: center;
   position: relative;
   padding: clamp(18px, 3vw, 32px) clamp(24px, 6vw, 48px);
-  background: rgba(255, 244, 213, 0.94);
-  border: 2px solid rgba(10, 9, 3, 0.12);
+  background: transparent;
+  border: none;
   border-radius: clamp(22px, 4vw, 36px);
-  box-shadow: 0 24px 40px rgba(10, 9, 3, 0.22);
+  box-shadow: none;
   pointer-events: auto;
   z-index: 1;
 }
 
 .teach-content::before {
-  content: "";
-  position: absolute;
-  top: clamp(-34px, -4vw, -20px);
-  left: 50%;
-  transform: translateX(-50%) rotate(1.6deg);
-  width: clamp(120px, 28vw, 220px);
-  height: clamp(18px, 3.2vw, 30px);
-  background: rgba(255, 255, 255, 0.78);
-  border-radius: 6px;
-  box-shadow: 0 12px 20px rgba(10, 9, 3, 0.2);
-  pointer-events: none;
-  z-index: 2;
+  display: none;
 }
 
 .teach-line {
@@ -1579,16 +1620,12 @@ body.is-fullscreen #toolbarBottom {
     height: 64px;
   }
 
-  .bottom-toolbar__sliders {
-    justify-content: flex-start;
+  .control-popover {
+    flex: 1 1 min(100%, 360px);
   }
 
-  .bottom-toolbar__slider {
-    flex: 1 1 min(100%, 320px);
-  }
-
-  .bottom-toolbar__slider .slider {
-    width: clamp(160px, 60vw, 240px);
+  .control-popover__panel {
+    min-width: clamp(220px, 64vw, 320px);
   }
 
   #toolbarBottom {

--- a/index.html
+++ b/index.html
@@ -70,7 +70,6 @@
       title="Teach Handwriting information and feedback"
     >
       <span aria-hidden="true" class="info-panel-toggle__icon">i</span>
-      <span class="info-panel-toggle__label">Teach Handwriting</span>
     </button>
 
     <div id="infoPanelBackdrop" class="info-panel-backdrop" hidden></div>
@@ -161,153 +160,31 @@
           </form>
         </section>
       </div>
-    </section>
+      </section>
 
-codex/refactor-handwriting-feature-layout
-    <main class="main-container" role="main">
+    <main class="main-container disable-select" role="main">
       <div class="app-shell disable-select">
         <section
           id="toolbarTop"
           class="toolbar toolbar--top"
-
-    <header class="title-container" role="banner">
-      <div class="title-texts">
-        <h1 class="title-text">Master handwriting</h1>
-      </div>
-    </header>
-
-    <main class="main-container disable-select" role="main">
-      <div id="writerContainer" class="writer-container">
-        <div class="board-layout">
-          <aside class="side-panel side-panel--left" aria-label="Drawing controls">
-            <button class="btn icon side-panel__button" id="btnUndo" type="button" aria-label="Undo" title="Undo">
-              <svg aria-hidden="true"><use href="assets/icons.svg#undo"></use></svg>
-            </button>
-            <button class="btn icon side-panel__button" id="btnRedo" type="button" aria-label="Redo" title="Redo">
-              <svg aria-hidden="true"><use href="assets/icons.svg#redo"></use></svg>
-            </button>
-            <button class="btn icon side-panel__button" id="btnZoomOut" type="button" aria-label="Zoom out" title="Zoom out">
-              <svg aria-hidden="true"><use href="assets/icons.svg#zoom-out"></use></svg>
-            </button>
-            <button class="btn icon side-panel__button" id="btnZoomIn" type="button" aria-label="Zoom in" title="Zoom in">
-              <svg aria-hidden="true"><use href="assets/icons.svg#zoom-in"></use></svg>
-            </button>
-            <button
-              class="btn icon side-panel__button"
-              id="btnTimer"
-              type="button"
-              aria-label="Timer"
-              title="Timer"
-              aria-haspopup="dialog"
-              aria-expanded="false"
-              aria-pressed="false"
-            >
-              <svg aria-hidden="true"><use href="assets/icons.svg#timer"></use></svg>
-            </button>
-            <button
-              class="btn icon side-panel__button"
-              id="btnFullscreenLeft"
-              type="button"
-              data-action="fullscreen"
-              aria-label="Fullscreen"
-              title="Fullscreen"
-            >
-              <svg aria-hidden="true"><use href="assets/icons.svg#fullscreen"></use></svg>
-            </button>
-          </aside>
-
-          <div class="board-wrapper">
-            <div id="writerBoard" class="writer-board">
-              <canvas id="writerPage" width="1200" height="600"></canvas>
-              <canvas id="writerTrace" width="1200" height="600"></canvas>
-              <canvas id="writerLines" width="1200" height="600"></canvas>
-              <canvas id="writer" width="1200" height="600"></canvas>
-              <canvas id="writerMask" width="1200" height="600"></canvas>
-              <div id="teachOverlay" class="teach-overlay" aria-live="polite"></div>
-            </div>
-
-            <div id="boardHeader" class="board-header">
-              <div class="board-header__title">
-                <div
-                  id="boardLessonTitle"
-                  class="board-lesson-title is-hidden"
-                  aria-live="polite"
-                  aria-hidden="true"
-                ></div>
-              </div>
-              <div class="board-header__date">
-                <div id="boardDate" aria-label="Date" role="button" tabindex="0">Loading date…</div>
-              </div>
-            </div>
-            <div id="retroTv" class="tv-off" aria-hidden="true">
-              <div class="tv-frame">
-                <div id="tvPlayer" class="tv-screen" title="Retro TV" role="presentation"></div>
-                <div class="tv-overlay" aria-hidden="true"></div>
-              </div>
-            </div>
-
-            <div id="timerProgress" aria-hidden="true"></div>
-          </div>
-
-          <aside class="side-panel side-panel--right" aria-label="Playback controls">
-            <button class="teach-button side-panel__action" id="btnTeachNext" type="button" disabled>
-              Next
-              <span aria-hidden="true" class="teach-button__arrow">➜</span>
-            </button>
-            <button
-              class="btn icon side-panel__button"
-              id="btnPalette"
-              type="button"
-              aria-label="Pen colour"
-              title="Pen colour"
-              aria-haspopup="dialog"
-              aria-expanded="false"
-            >
-              <svg aria-hidden="true"><use href="assets/icons.svg#palette"></use></svg>
-            </button>
-            <button class="btn icon btn-primary side-panel__button" id="btnRewrite" type="button" aria-label="Rewrite" title="Rewrite" aria-pressed="false">
-              <svg aria-hidden="true"><use href="assets/icons.svg#play"></use></svg>
-            </button>
-            <button class="btn icon side-panel__button" id="btnUploadPen" type="button" aria-label="Upload pen image" title="Upload pen image">
-              <svg aria-hidden="true"><use href="assets/icons.svg#upload"></use></svg>
-            </button>
-            <button class="btn icon side-panel__button is-disabled" id="btnRemovePenImage" type="button" aria-label="Remove custom pen image" title="Remove custom pen image" disabled>
-              <svg aria-hidden="true"><use href="assets/icons.svg#close"></use></svg>
-            </button>
-            <button
-              class="btn icon side-panel__button"
-              id="btnFullscreen"
-              type="button"
-              data-action="fullscreen"
-              aria-label="Fullscreen"
-              title="Fullscreen"
-            >
-              <svg aria-hidden="true"><use href="assets/icons.svg#fullscreen"></use></svg>
-            </button>
-          </aside>
-        </div>
-
-        <div
-          id="toolbarBottom"
-main
           role="region"
-          aria-label="Lesson and practice settings"
+          aria-label="Lesson setup"
         >
           <div class="toolbar-top__inner">
-            <div class="lesson-title-field">
+            <div class="lesson-title-field toolbar-top__lesson">
               <label class="lesson-title-label" for="inputLessonTitle">Lesson title</label>
               <div class="lesson-title-input-row">
                 <input
                   type="text"
                   id="inputLessonTitle"
                   class="lesson-title-input"
-                  placeholder="Lesson title here"
+                  placeholder="Put the lesson title"
                   autocomplete="off"
                 />
                 <button
                   type="button"
                   id="btnLessonTitleApply"
-                  class="lesson-title-apply is-disabled"
+                  class="lesson-title-apply teach-button is-disabled"
                   disabled
                 >
                   Display
@@ -322,7 +199,7 @@ main
                   id="teachTextInput"
                   class="teach-input"
                   type="text"
-                  placeholder="Type a sentence for the board"
+                  placeholder="Put the practice text"
                   autocomplete="off"
                 />
                 <button class="teach-button" id="btnTeach" type="button">Teach</button>
@@ -331,119 +208,144 @@ main
           </div>
         </section>
 
-        <div id="writerContainer" class="writer-container">
-          <div class="board-layout">
-            <aside class="side-panel side-panel--left" aria-label="Drawing controls">
-              <button class="btn icon side-panel__button" id="btnZoomOut" type="button" aria-label="Zoom out" title="Zoom out">
-                <svg aria-hidden="true"><use href="assets/icons.svg#zoom-out"></use></svg>
-              </button>
-              <button class="btn icon side-panel__button" id="btnZoomIn" type="button" aria-label="Zoom in" title="Zoom in">
-                <svg aria-hidden="true"><use href="assets/icons.svg#zoom-in"></use></svg>
-              </button>
-              <button
-                class="btn icon side-panel__button"
-                id="btnTimer"
-                type="button"
-                aria-label="Timer"
-                title="Timer"
-                aria-haspopup="dialog"
-                aria-expanded="false"
-                aria-pressed="false"
-              >
-                <svg aria-hidden="true"><use href="assets/icons.svg#timer"></use></svg>
-              </button>
-              <button
-                class="btn icon side-panel__button"
-                id="btnFullscreenLeft"
-                type="button"
-                data-action="fullscreen"
-                aria-label="Fullscreen"
-                title="Fullscreen"
-              >
-                <svg aria-hidden="true"><use href="assets/icons.svg#fullscreen"></use></svg>
-              </button>
-            </aside>
-
-            <div class="board-wrapper">
-              <div id="writerBoard" class="writer-board">
-                <canvas id="writerPage" width="1200" height="600"></canvas>
-                <canvas id="writerTrace" width="1200" height="600"></canvas>
-                <canvas id="writerLines" width="1200" height="600"></canvas>
-                <canvas id="writer" width="1200" height="600"></canvas>
-                <canvas id="writerMask" width="1200" height="600"></canvas>
-                <div id="teachOverlay" class="teach-overlay" aria-live="polite"></div>
-              </div>
-
-              <div id="boardHeader" class="board-header">
-                <div id="boardDate" aria-label="Date" role="button" tabindex="0">Loading date…</div>
-                <div
-                  id="boardLessonTitle"
-                  class="board-lesson-title is-hidden"
-                  aria-live="polite"
-                  aria-hidden="true"
-                ></div>
-              </div>
-              <div id="retroTv" class="tv-off" aria-hidden="true">
-                <div class="tv-frame">
-                  <div id="tvPlayer" class="tv-screen" title="Retro TV" role="presentation"></div>
-                  <div class="tv-overlay" aria-hidden="true"></div>
-                </div>
-              </div>
-
-              <div id="timerProgress" aria-hidden="true"></div>
-
-              <button class="board-fab board-fab--undo" id="btnUndo" type="button" aria-label="Undo" title="Undo">
-                <svg aria-hidden="true"><use href="assets/icons.svg#undo"></use></svg>
-              </button>
-
-              <button
-                class="board-fab board-fab--next"
-                id="btnTeachNext"
-                type="button"
-                aria-label="Redo (top) or Next (bottom)"
-                title="Tap top for redo, bottom for next"
-                disabled
-              >
-                <span class="board-fab__segment board-fab__segment--redo" aria-hidden="true">
-                  <svg aria-hidden="true"><use href="assets/icons.svg#redo"></use></svg>
-                  <span class="board-fab__label">Redo</span>
-                </span>
-                <span class="board-fab__segment board-fab__segment--next">
-                  <span class="board-fab__label">Next</span>
-                  <span aria-hidden="true" class="teach-button__arrow">➜</span>
-                </span>
-              </button>
+        <div class="board-region">
+          <div id="boardHeader" class="board-header" role="presentation">
+            <div class="board-header__title">
+              <div
+                id="boardLessonTitle"
+                class="board-lesson-title is-hidden"
+                aria-live="polite"
+                aria-hidden="true"
+              ></div>
             </div>
+            <div class="board-header__date">
+              <div id="boardDate" aria-label="Date" role="button" tabindex="0">Loading date…</div>
+            </div>
+          </div>
 
-            <aside class="side-panel side-panel--right" aria-label="Playback controls">
-              <button
-                class="btn icon side-panel__button"
-                id="btnPalette"
-                type="button"
-                aria-label="Pen colour"
-                title="Pen colour"
-                aria-haspopup="dialog"
-                aria-expanded="false"
-              >
-                <svg aria-hidden="true"><use href="assets/icons.svg#palette"></use></svg>
-              </button>
-              <button class="btn icon side-panel__button" id="btnUploadPen" type="button" aria-label="Upload pen image" title="Upload pen image">
-                <svg aria-hidden="true"><use href="assets/icons.svg#upload"></use></svg>
-              </button>
-              <button class="btn icon side-panel__button is-disabled" id="btnRemovePenImage" type="button" aria-label="Remove custom pen image" title="Remove custom pen image" disabled>
-                <svg aria-hidden="true"><use href="assets/icons.svg#close"></use></svg>
-              </button>
-              <button
-                class="btn icon side-panel__button"
-                id="btnFullscreen"
-                type="button"
-                data-action="fullscreen"
-                aria-label="Fullscreen"
-                title="Fullscreen"
-              >
-                <svg aria-hidden="true"><use href="assets/icons.svg#fullscreen"></use></svg>
-              </button>
-            </aside>
+          <div id="writerContainer" class="writer-container">
+            <div class="board-layout">
+              <aside class="side-panel side-panel--left" aria-label="Drawing controls">
+                <button class="btn icon side-panel__button" id="btnUndo" type="button" aria-label="Undo" title="Undo">
+                  <svg aria-hidden="true"><use href="assets/icons.svg#undo"></use></svg>
+                </button>
+                <button class="btn icon side-panel__button" id="btnRedo" type="button" aria-label="Redo" title="Redo">
+                  <svg aria-hidden="true"><use href="assets/icons.svg#redo"></use></svg>
+                </button>
+                <button class="btn icon side-panel__button" id="btnZoomOut" type="button" aria-label="Zoom out" title="Zoom out">
+                  <svg aria-hidden="true"><use href="assets/icons.svg#zoom-out"></use></svg>
+                </button>
+                <button class="btn icon side-panel__button" id="btnZoomIn" type="button" aria-label="Zoom in" title="Zoom in">
+                  <svg aria-hidden="true"><use href="assets/icons.svg#zoom-in"></use></svg>
+                </button>
+                <button
+                  class="btn icon side-panel__button"
+                  id="btnBackgroundWhite"
+                  type="button"
+                  aria-label="White background"
+                  title="White background"
+                  aria-pressed="false"
+                >
+                  <svg aria-hidden="true"><use href="assets/icons.svg#page-blank"></use></svg>
+                </button>
+                <button
+                  class="btn icon side-panel__button"
+                  id="btnBackgroundLines"
+                  type="button"
+                  aria-label="Lines background"
+                  title="Lines background"
+                  aria-pressed="false"
+                >
+                  <svg aria-hidden="true"><use href="assets/icons.svg#page-lines"></use></svg>
+                </button>
+                <button
+                  class="btn icon side-panel__button"
+                  id="btnTimer"
+                  type="button"
+                  aria-label="Timer"
+                  title="Timer"
+                  aria-haspopup="dialog"
+                  aria-expanded="false"
+                  aria-pressed="false"
+                >
+                  <svg aria-hidden="true"><use href="assets/icons.svg#timer"></use></svg>
+                </button>
+                <button
+                  class="btn icon side-panel__button"
+                  id="btnFullscreenLeft"
+                  type="button"
+                  data-action="fullscreen"
+                  aria-label="Fullscreen"
+                  title="Fullscreen"
+                >
+                  <svg aria-hidden="true"><use href="assets/icons.svg#fullscreen"></use></svg>
+                </button>
+              </aside>
+
+              <div class="board-wrapper">
+                <div class="board-frame">
+                  <div id="writerBoard" class="writer-board">
+                    <div class="writer-board__content">
+                      <canvas id="writerPage" width="1200" height="600"></canvas>
+                      <canvas id="writerTrace" width="1200" height="600"></canvas>
+                      <canvas id="writerLines" width="1200" height="600"></canvas>
+                      <canvas id="writer" width="1200" height="600"></canvas>
+                      <canvas id="writerMask" width="1200" height="600"></canvas>
+                      <div id="teachOverlay" class="teach-overlay" aria-live="polite"></div>
+                    </div>
+                  </div>
+                </div>
+
+                <div id="retroTv" class="tv-off" aria-hidden="true">
+                  <div class="tv-frame">
+                    <div id="tvPlayer" class="tv-screen" title="Retro TV" role="presentation"></div>
+                    <div class="tv-overlay" aria-hidden="true"></div>
+                  </div>
+                </div>
+
+                <div id="timerProgress" aria-hidden="true"></div>
+              </div>
+
+              <aside class="side-panel side-panel--right" aria-label="Playback controls">
+                <button class="teach-button side-panel__action" id="btnTeachNext" type="button" disabled>
+                  Next
+                  <span aria-hidden="true" class="teach-button__arrow">➜</span>
+                </button>
+                <button
+                  class="btn icon side-panel__button"
+                  id="btnPalette"
+                  type="button"
+                  aria-label="Pen colour"
+                  title="Pen colour"
+                  aria-haspopup="dialog"
+                  aria-expanded="false"
+                >
+                  <svg aria-hidden="true"><use href="assets/icons.svg#palette"></use></svg>
+                </button>
+                <button class="btn icon btn-primary side-panel__button" id="btnRewrite" type="button" aria-label="Rewrite" title="Rewrite" aria-pressed="false">
+                  <svg aria-hidden="true"><use href="assets/icons.svg#play"></use></svg>
+                </button>
+                <button class="btn icon side-panel__button" id="btnSpeedQuick" type="button" aria-label="Rewrite speed" title="Rewrite speed">
+                  <svg aria-hidden="true"><use href="assets/icons.svg#speed"></use></svg>
+                </button>
+                <button class="btn icon side-panel__button" id="btnUploadPen" type="button" aria-label="Upload pen image" title="Upload pen image">
+                  <svg aria-hidden="true"><use href="assets/icons.svg#upload"></use></svg>
+                </button>
+                <button class="btn icon side-panel__button is-disabled" id="btnRemovePenImage" type="button" aria-label="Remove custom pen image" title="Remove custom pen image" disabled>
+                  <svg aria-hidden="true"><use href="assets/icons.svg#close"></use></svg>
+                </button>
+                <button
+                  class="btn icon side-panel__button"
+                  id="btnFullscreen"
+                  type="button"
+                  data-action="fullscreen"
+                  aria-label="Fullscreen"
+                  title="Fullscreen"
+                >
+                  <svg aria-hidden="true"><use href="assets/icons.svg#fullscreen"></use></svg>
+                </button>
+              </aside>
+            </div>
           </div>
         </div>
 
@@ -451,14 +353,24 @@ main
           id="toolbarBottom"
           class="toolbar toolbar--bottom"
           role="region"
-          aria-label="Drawing speed and playback controls"
+          aria-label="Drawing adjustments"
         >
           <div class="bottom-toolbar__inner">
-            <div class="bottom-toolbar__sliders" aria-label="Drawing speed and pen size controls">
-              <div class="slider-control slider-control--stacked bottom-toolbar__slider" id="penSizeControl">
-                <span class="icon-leading" aria-hidden="true">
+            <div class="control-popover" data-control="pen">
+              <button
+                class="control-popover__toggle"
+                id="btnPenSizeToggle"
+                type="button"
+                aria-expanded="false"
+                aria-controls="penSizePanel"
+              >
+                <span class="control-popover__icon" aria-hidden="true">
                   <svg><use href="assets/icons.svg#pen"></use></svg>
                 </span>
+                <span class="control-popover__label">Pen size</span>
+                <span class="control-popover__value" id="penSizeValue">6</span>
+              </button>
+              <div class="control-popover__panel" id="penSizePanel" hidden>
                 <label class="visually-hidden" for="sliderPenSize">Pen size</label>
                 <input
                   id="sliderPenSize"
@@ -474,10 +386,23 @@ main
                   aria-label="Pen size"
                 />
               </div>
-              <div class="slider-control slider-control--compact bottom-toolbar__slider" id="speedControl">
-                <span class="icon-leading" aria-hidden="true">
-                  <svg><use href="assets/icons.svg#turtle"></use></svg>
+            </div>
+
+            <div class="control-popover" data-control="speed">
+              <button
+                class="control-popover__toggle"
+                id="btnSpeedToggle"
+                type="button"
+                aria-expanded="false"
+                aria-controls="speedPanel"
+              >
+                <span class="control-popover__icon" aria-hidden="true">
+                  <svg><use href="assets/icons.svg#speed"></use></svg>
                 </span>
+                <span class="control-popover__label">Rewrite speed</span>
+                <span class="control-popover__value" id="speedValue">2×</span>
+              </button>
+              <div class="control-popover__panel" id="speedPanel" hidden>
                 <label class="visually-hidden" for="sliderSpeed">Rewrite speed</label>
                 <input
                   id="sliderSpeed"
@@ -494,9 +419,6 @@ main
                 />
               </div>
             </div>
-            <button class="btn icon btn-primary bottom-toolbar__play" id="btnRewrite" type="button" aria-label="Rewrite" title="Rewrite" aria-pressed="false">
-              <svg aria-hidden="true"><use href="assets/icons.svg#play"></use></svg>
-            </button>
           </div>
         </section>
       </div>


### PR DESCRIPTION
## Summary
- move the lesson/date header above the board, wrap the canvases in a fixed frame, and add quick background buttons for blank and lined pages
- convert the pen size and rewrite speed sliders into popover buttons with value readouts and add a speed shortcut under the replay control
- strip backgrounds from the practice overlay, preview letters, and board date to keep the workspace uncluttered

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d3ca624518833191d4e43abe3f72b4