### PR TITLE
Use new phonics lines board background asset

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1552,6 +1552,7 @@ body.is-fullscreen #toolbarBottom {
 }
 
 .style-preview.style-phonics-lines {
+  /* Keep in sync with PHONICS_LINES_ASSET_PATH in js/Controls.js */
   background-image: url("../assets/icons/Phonics lines.png");
   background-repeat: no-repeat;
   background-size: cover;

--- a/js/Controls.js
+++ b/js/Controls.js
@@ -26,7 +26,8 @@ const PEN_COLOUR_SWATCHES = [
   '#ffffff'
 ];
 
-const PHONICS_LINES_IMAGE_SRC = getAssetUrl('icons/Phonics lines.png');
+const PHONICS_LINES_ASSET_PATH = 'icons/Phonics lines.png';
+const PHONICS_LINES_IMAGE_SRC = getAssetUrl(PHONICS_LINES_ASSET_PATH);
 let phonicsLinesImage = null;
 let phonicsLinesImagePromise = null;
 
@@ -1499,7 +1500,7 @@ function drawPhonicsLinesGuidelines(ctx, width, height) {
         return image;
       })
       .catch(error => {
-        console.warn('Unable to load phonics lines background.', error);
+        console.warn(`Unable to load phonics lines background from "${PHONICS_LINES_ASSET_PATH}".`, error);
         phonicsLinesImagePromise = null;
         return null;
       });


### PR DESCRIPTION
## Summary
- update the board controls to resolve the phonics lines background from the new icons/Phonics lines.png asset
- document the matching preview background path so CSS stays aligned with the JavaScript constant
- improve error logging when the phonics lines image fails to load by referencing the asset path

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3ea16ec1483318ce8f8b7f26d9bf2