### PR TITLE
Enhance fullscreen layout and add rainbow pen option

### DIFF
--- a/assets/icons.svg
+++ b/assets/icons.svg
@@ -94,4 +94,36 @@
     <polyline points="21 15 21 21 15 21" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
     <polyline points="9 21 3 21 3 15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
   </symbol>
+  <symbol id="title" viewBox="0 0 24 24">
+    <line x1="5" y1="5" x2="19" y2="5" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+    <line x1="12" y1="5" x2="12" y2="19" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+  </symbol>
+  <symbol id="practice" viewBox="0 0 24 24">
+    <circle cx="12" cy="6" r="3" fill="none" stroke="currentColor" stroke-width="2" />
+    <path
+      d="M5 13c0-2.8 2.2-5 5-5h1.2l1.6-3.1a2 2 0 0 1 2.7-.8l1 .5a2 2 0 0 1 .8 2.7L15 11h1.9C18.6 11 20 12.4 20 14c0 3.3-2.7 6-6 6H10c-3.3 0-6-2.7-6-6"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </symbol>
+  <symbol id="trash" viewBox="0 0 24 24">
+    <path d="M4 7h16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+    <path d="M6 7l1 11a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2l1-11" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" />
+    <path d="M9 7V5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+    <line x1="10" y1="11" x2="10" y2="17" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+    <line x1="14" y1="11" x2="14" y2="17" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+  </symbol>
+  <symbol id="view" viewBox="0 0 24 24">
+    <path d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7S2 12 2 12z" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" />
+    <circle cx="12" cy="12" r="3" fill="none" stroke="currentColor" stroke-width="2" />
+  </symbol>
+  <symbol id="arrow-left" viewBox="0 0 24 24">
+    <polyline points="15 5 8 12 15 19" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  </symbol>
+  <symbol id="arrow-right" viewBox="0 0 24 24">
+    <polyline points="9 5 16 12 9 19" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  </symbol>
 </svg>

--- a/css/style.css
+++ b/css/style.css
@@ -227,7 +227,6 @@ body {
   padding: clamp(16px, 3vw, 28px);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
   overflow: visible;
-  --zoom-level: 1;
   width: 100%;
   max-width: 100%;
   flex: 1;
@@ -267,8 +266,6 @@ body {
   align-items: stretch;
   width: 100%;
   height: 100%;
-  transform: scale(var(--zoom-level, 1));
-  transform-origin: top center;
   will-change: transform;
   border-radius: inherit;
 }
@@ -568,6 +565,7 @@ body {
 
 body.is-fullscreen {
   align-items: stretch;
+  background: var(--color-aerospace-orange);
 }
 
 body.is-fullscreen .title-container,
@@ -582,6 +580,21 @@ body.is-fullscreen .main-container {
   padding: clamp(12px, 3vw, 32px);
   gap: 0;
   align-items: center;
+}
+
+body.is-fullscreen .side-panel {
+  padding: clamp(6px, 1.4vw, 12px);
+  gap: clamp(6px, 1.6vw, 12px);
+}
+
+body.is-fullscreen .side-panel__button {
+  width: 48px;
+  height: 48px;
+}
+
+body.is-fullscreen .btn.icon.side-panel__button svg {
+  width: 24px;
+  height: 24px;
 }
 
 body.is-fullscreen .app-shell {
@@ -843,12 +856,100 @@ body.board-controls-hidden #toolbarBottom {
   display: none;
 }
 
+.fullscreen-toolbar {
+  display: none;
+  width: 100%;
+  flex-direction: column;
+  gap: clamp(16px, 3vw, 24px);
+}
+
+.fullscreen-toolbar__sliders {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(16px, 3vw, 28px);
+}
+
+.fullscreen-slider {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 18px;
+  background: rgba(255, 244, 213, 0.55);
+  border: 1px solid rgba(10, 9, 3, 0.12);
+  box-shadow: 0 10px 20px rgba(10, 9, 3, 0.18);
+}
+
+.fullscreen-slider__label {
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.fullscreen-slider__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--color-ut-orange);
+}
+
+.fullscreen-slider .slider {
+  width: clamp(200px, 32vw, 360px);
+}
+
+.fullscreen-toolbar__action {
+  width: 64px;
+  height: 64px;
+}
+
+.fullscreen-palette {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(44px, 1fr));
+  gap: 12px;
+  width: 100%;
+}
+
+.fullscreen-palette .swatch {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1 / 1;
+}
+
+.swatch--rainbow {
+  background: var(--swatch-colour, linear-gradient(135deg, #ff004d, #ffa500, #ffee00, #00d084, #1e4dd8, #7f3f98));
+}
+
 #toolbarBottom.is-fullscreen-active {
   transform: translateY(0);
 }
 
 #toolbarBottom.is-collapsed {
   box-shadow: 0 14px 28px rgba(10, 9, 3, 0.18);
+}
+
+body.is-fullscreen #toolbarBottom {
+  padding: clamp(14px, 2.4vw, 22px);
+}
+
+body.is-fullscreen .bottom-toolbar__inner {
+  flex-direction: column;
+  align-items: stretch;
+  gap: clamp(16px, 3vw, 24px);
+}
+
+body.is-fullscreen .control-popover {
+  display: none;
+}
+
+body.is-fullscreen .fullscreen-toolbar {
+  display: flex;
+}
+
+body.is-fullscreen #btnPalette {
+  display: none;
 }
 
 .teach-field {
@@ -1244,6 +1345,10 @@ body.board-controls-hidden #toolbarBottom {
   bottom: 6px;
   right: 6px;
   box-shadow: 0 0 0 2px rgba(10, 9, 3, 0.2);
+}
+
+#btnPalette.is-rainbow::after {
+  background: conic-gradient(from 0deg, #ff004d, #ffa500, #ffee00, #00d084, #1e4dd8, #7f3f98, #ff004d);
 }
 
 .btn.icon.is-disabled,

--- a/index.html
+++ b/index.html
@@ -310,36 +310,69 @@
               </div>
 
               <aside class="side-panel side-panel--right" aria-label="Playback controls">
-                <button class="teach-button side-panel__action" id="btnLessonTitlePrompt" type="button">
-                  Lesson title
-                </button>
-                <button class="teach-button side-panel__action" id="btnPracticeTextPrompt" type="button">
-                  Practice text
-                </button>
-                <button class="teach-button side-panel__action" id="btnClearPracticeText" type="button">
-                  Clean practice
+                <button
+                  class="btn icon side-panel__button"
+                  id="btnLessonTitlePrompt"
+                  type="button"
+                  aria-label="Lesson title"
+                  title="Lesson title"
+                >
+                  <svg aria-hidden="true"><use href="assets/icons.svg#title"></use></svg>
+                  <span class="visually-hidden">Lesson title</span>
                 </button>
                 <button
-                  class="teach-button side-panel__action"
+                  class="btn icon side-panel__button"
+                  id="btnPracticeTextPrompt"
+                  type="button"
+                  aria-label="Practice text"
+                  title="Practice text"
+                >
+                  <svg aria-hidden="true"><use href="assets/icons.svg#practice"></use></svg>
+                  <span class="visually-hidden">Practice text</span>
+                </button>
+                <button
+                  class="btn icon side-panel__button"
+                  id="btnClearPracticeText"
+                  type="button"
+                  aria-label="Clean practice"
+                  title="Clean practice"
+                >
+                  <svg aria-hidden="true"><use href="assets/icons.svg#trash"></use></svg>
+                  <span class="visually-hidden">Clean practice</span>
+                </button>
+                <button
+                  class="btn icon side-panel__button"
                   id="btnHideLetters"
                   type="button"
                   aria-pressed="false"
+                  aria-label="Show letters"
+                  title="Show letters"
                   disabled
                 >
-                  Show letters
+                  <svg aria-hidden="true"><use href="assets/icons.svg#view"></use></svg>
+                  <span class="visually-hidden" data-button-label>Show letters</span>
                 </button>
                 <button
-                  class="teach-button side-panel__action"
+                  class="btn icon side-panel__button"
                   id="btnTeachPrevious"
                   type="button"
                   aria-label="Show previous letter"
+                  title="Previous letter"
                   disabled
                 >
-                  Before
+                  <svg aria-hidden="true"><use href="assets/icons.svg#arrow-left"></use></svg>
+                  <span class="visually-hidden">Previous letter</span>
                 </button>
-                <button class="teach-button side-panel__action" id="btnTeachNext" type="button" disabled>
-                  Next
-                  <span aria-hidden="true" class="teach-button__arrow">➜</span>
+                <button
+                  class="btn icon side-panel__button"
+                  id="btnTeachNext"
+                  type="button"
+                  aria-label="Show next letter"
+                  title="Next letter"
+                  disabled
+                >
+                  <svg aria-hidden="true"><use href="assets/icons.svg#arrow-right"></use></svg>
+                  <span class="visually-hidden">Next letter</span>
                 </button>
                 <button
                   class="btn icon side-panel__button"
@@ -351,9 +384,6 @@
                   aria-expanded="false"
                 >
                   <svg aria-hidden="true"><use href="assets/icons.svg#palette"></use></svg>
-                </button>
-                <button class="btn icon btn-primary side-panel__button" id="btnRewrite" type="button" aria-label="Rewrite" title="Rewrite" aria-pressed="false">
-                  <svg aria-hidden="true"><use href="assets/icons.svg#play"></use></svg>
                 </button>
                 <button class="btn icon side-panel__button" id="btnSpeedQuick" type="button" aria-label="Rewrite speed" title="Rewrite speed">
                   <svg aria-hidden="true"><use href="assets/icons.svg#speed"></use></svg>
@@ -449,6 +479,79 @@
                 />
               </div>
             </div>
+
+            <div class="fullscreen-toolbar" id="fullscreenToolbar">
+              <div class="fullscreen-toolbar__sliders">
+                <div class="fullscreen-slider" id="fullscreenPenSizeControl">
+                  <label class="fullscreen-slider__label" for="sliderPenSizeFullscreen">Pen size</label>
+                  <input
+                    id="sliderPenSizeFullscreen"
+                    class="slider"
+                    type="range"
+                    min="1"
+                    max="40"
+                    value="6"
+                    step="1"
+                    aria-valuemin="1"
+                    aria-valuemax="40"
+                    aria-valuenow="6"
+                    aria-label="Pen size"
+                  />
+                  <span class="fullscreen-slider__value" id="penSizeValueFullscreen">6</span>
+                </div>
+
+                <button
+                  class="btn icon btn-primary fullscreen-toolbar__action"
+                  id="btnRewrite"
+                  type="button"
+                  aria-label="Rewrite"
+                  title="Rewrite"
+                  aria-pressed="false"
+                >
+                  <svg aria-hidden="true"><use href="assets/icons.svg#play"></use></svg>
+                </button>
+
+                <div class="fullscreen-slider" id="fullscreenSpeedControl">
+                  <label class="fullscreen-slider__label" for="sliderSpeedFullscreen">Rewrite speed</label>
+                  <input
+                    id="sliderSpeedFullscreen"
+                    class="slider"
+                    type="range"
+                    min="0.5"
+                    max="8"
+                    step="0.1"
+                    value="2"
+                    aria-valuemin="0.5"
+                    aria-valuemax="8"
+                    aria-valuenow="2"
+                    aria-label="Rewrite speed"
+                  />
+                  <span class="fullscreen-slider__value" id="speedValueFullscreen">2×</span>
+                </div>
+              </div>
+
+              <div class="fullscreen-palette" id="fullscreenPalette" role="list">
+                <button class="swatch" type="button" data-colour="#111111" aria-label="Black" style="--swatch-colour: #111111"></button>
+                <button class="swatch" type="button" data-colour="#444444" aria-label="Dark grey" style="--swatch-colour: #444444"></button>
+                <button class="swatch" type="button" data-colour="#1e4dd8" aria-label="Blue" style="--swatch-colour: #1e4dd8"></button>
+                <button class="swatch" type="button" data-colour="#d8342c" aria-label="Red" style="--swatch-colour: #d8342c"></button>
+                <button class="swatch" type="button" data-colour="#0f7a3d" aria-label="Green" style="--swatch-colour: #0f7a3d"></button>
+                <button class="swatch" type="button" data-colour="#7f3f98" aria-label="Purple" style="--swatch-colour: #7f3f98"></button>
+                <button class="swatch" type="button" data-colour="#f17f1a" aria-label="Orange" style="--swatch-colour: #f17f1a"></button>
+                <button class="swatch" type="button" data-colour="#5b3a1d" aria-label="Brown" style="--swatch-colour: #5b3a1d"></button>
+                <button class="swatch" type="button" data-colour="#e969ad" aria-label="Pink" style="--swatch-colour: #e969ad"></button>
+                <button class="swatch" type="button" data-colour="#00bcd4" aria-label="Cyan" style="--swatch-colour: #00bcd4"></button>
+                <button class="swatch" type="button" data-colour="#ffffff" aria-label="White" style="--swatch-colour: #ffffff"></button>
+                <button class="swatch" type="button" data-colour="#ffd700" aria-label="Yellow" style="--swatch-colour: #ffd700"></button>
+                <button
+                  class="swatch swatch--rainbow"
+                  type="button"
+                  data-colour="rainbow"
+                  aria-label="Rainbow"
+                  style="--swatch-colour: conic-gradient(from 0deg, #ff004d, #ffa500, #ffee00, #00d084, #1e4dd8, #7f3f98, #ff004d)"
+                ></button>
+              </div>
+            </div>
           </div>
         </section>
       </div>
@@ -494,6 +597,14 @@
         <button class="swatch" type="button" data-colour="#e969ad" aria-label="Pink" style="--swatch-colour: #e969ad"></button>
         <button class="swatch" type="button" data-colour="#00bcd4" aria-label="Cyan" style="--swatch-colour: #00bcd4"></button>
         <button class="swatch" type="button" data-colour="#ffffff" aria-label="White" style="--swatch-colour: #ffffff"></button>
+        <button class="swatch" type="button" data-colour="#ffd700" aria-label="Yellow" style="--swatch-colour: #ffd700"></button>
+        <button
+          class="swatch swatch--rainbow"
+          type="button"
+          data-colour="rainbow"
+          aria-label="Rainbow"
+          style="--swatch-colour: conic-gradient(from 0deg, #ff004d, #ffa500, #ffee00, #00d084, #1e4dd8, #7f3f98, #ff004d)"
+        ></button>
         <label class="custom-colour" for="colorPicker">
           <span>Custom</span>
           <input type="color" id="colorPicker" aria-label="Custom colour" />

--- a/js/Controls.js
+++ b/js/Controls.js
@@ -23,8 +23,12 @@ const PEN_COLOUR_SWATCHES = [
   '#5b3a1d',
   '#e969ad',
   '#00bcd4',
-  '#ffffff'
+  '#ffffff',
+  '#ffd700',
+  'rainbow'
 ];
+
+const RAINBOW_INDICATOR = 'conic-gradient(from 0deg, #ff004d, #ffa500, #ffee00, #00d084, #1e4dd8, #7f3f98, #ff004d)';
 
 const PHONICS_LINES_IMAGE_SRC = getAssetUrl('icons/Phonics lines.png');
 let phonicsLinesImage = null;
@@ -68,6 +72,10 @@ export class Controls {
 
     this.speedSlider = document.getElementById('sliderSpeed');
     this.penSizeSlider = document.getElementById('sliderPenSize');
+    this.penSizeSliderFullscreen = document.getElementById('sliderPenSizeFullscreen');
+    this.penSizeValueDisplay = document.getElementById('penSizeValueFullscreen');
+    this.speedSliderFullscreen = document.getElementById('sliderSpeedFullscreen');
+    this.speedValueDisplay = document.getElementById('speedValueFullscreen');
 
     this.penSizeToggleButton = document.getElementById('btnPenSizeToggle');
     this.penSizePanel = document.getElementById('penSizePanel');
@@ -92,6 +100,11 @@ export class Controls {
     this.paletteSwatches = this.palettePopover
       ? Array.from(this.palettePopover.querySelectorAll('.swatch[data-colour]'))
       : [];
+    this.fullscreenPalette = document.getElementById('fullscreenPalette');
+    this.fullscreenPaletteSwatches = this.fullscreenPalette
+      ? Array.from(this.fullscreenPalette.querySelectorAll('.swatch[data-colour]'))
+      : [];
+    this.allPaletteSwatches = [...this.paletteSwatches, ...this.fullscreenPaletteSwatches];
     this.customColourInput = document.getElementById('colorPicker');
 
     this.timerButton = document.getElementById('btnTimer');
@@ -127,6 +140,7 @@ export class Controls {
 
     this.storage = getLocalStorage();
     this.toolbarLayoutVersion = this.getStorageItem?.('ui.toolbarLayoutVersion') ?? null;
+    this.currentZoom = this.userData?.userSettings?.zoomLevel ?? DEFAULT_SETTINGS.zoomLevel;
 
     this.openPopover = null;
     this.openPopoverButton = null;
@@ -429,12 +443,14 @@ export class Controls {
       });
     }
 
-    this.paletteSwatches.forEach(button => {
+    this.allPaletteSwatches.forEach(button => {
       button.addEventListener('click', () => {
         const colour = button.dataset.colour;
         this.highlightPaletteSwatch(colour);
         this.setPenColour(colour, true);
-        this.closeOpenPopover();
+        if (this.palettePopover?.contains(button)) {
+          this.closeOpenPopover();
+        }
       });
     });
 
@@ -496,6 +512,36 @@ export class Controls {
       this.speedSlider.addEventListener('input', () => {
         const speed = clamp(
           Number(this.speedSlider.value) || DEFAULT_SETTINGS.rewriteSpeed,
+          REWRITE_SPEED_MIN,
+          REWRITE_SPEED_MAX
+        );
+        this.setRewriteSpeed(speed, true);
+      });
+    }
+
+    if (this.penSizeSliderFullscreen) {
+      this.penSizeSliderFullscreen.min = String(PEN_SIZE_MIN);
+      this.penSizeSliderFullscreen.max = String(PEN_SIZE_MAX);
+      this.penSizeSliderFullscreen.setAttribute('aria-valuemin', String(PEN_SIZE_MIN));
+      this.penSizeSliderFullscreen.setAttribute('aria-valuemax', String(PEN_SIZE_MAX));
+      this.penSizeSliderFullscreen.addEventListener('input', () => {
+        const value = clamp(
+          Number(this.penSizeSliderFullscreen.value) || DEFAULT_SETTINGS.selectedPenWidth,
+          PEN_SIZE_MIN,
+          PEN_SIZE_MAX
+        );
+        this.setPenSize(value, true);
+      });
+    }
+
+    if (this.speedSliderFullscreen) {
+      this.speedSliderFullscreen.min = String(REWRITE_SPEED_MIN);
+      this.speedSliderFullscreen.max = String(REWRITE_SPEED_MAX);
+      this.speedSliderFullscreen.setAttribute('aria-valuemin', String(REWRITE_SPEED_MIN));
+      this.speedSliderFullscreen.setAttribute('aria-valuemax', String(REWRITE_SPEED_MAX));
+      this.speedSliderFullscreen.addEventListener('input', () => {
+        const speed = clamp(
+          Number(this.speedSliderFullscreen.value) || DEFAULT_SETTINGS.rewriteSpeed,
           REWRITE_SPEED_MIN,
           REWRITE_SPEED_MAX
         );
@@ -1129,8 +1175,17 @@ export class Controls {
       this.penSizeSlider.setAttribute('aria-valuenow', String(size));
     }
 
+    if (this.penSizeSliderFullscreen && this.penSizeSliderFullscreen.value !== String(size)) {
+      this.penSizeSliderFullscreen.value = String(size);
+      this.penSizeSliderFullscreen.setAttribute('aria-valuenow', String(size));
+    }
+
     if (this.penSizeValueLabel) {
       this.penSizeValueLabel.textContent = String(size);
+    }
+
+    if (this.penSizeValueDisplay) {
+      this.penSizeValueDisplay.textContent = String(size);
     }
 
     this.setStorageItem('pen.size', String(size));
@@ -1149,12 +1204,14 @@ export class Controls {
   }
 
   clearPaletteSelection() {
-    this.paletteSwatches.forEach(button => button.classList.remove('is-selected'));
+    this.allPaletteSwatches.forEach(button => button.classList.remove('is-selected'));
   }
 
   highlightPaletteSwatch(colour) {
-    this.paletteSwatches.forEach(button => {
-      const isSelected = button.dataset.colour.toLowerCase() === (colour ?? '').toLowerCase();
+    const targetColour = typeof colour === 'string' ? colour.toLowerCase() : '';
+    this.allPaletteSwatches.forEach(button => {
+      const value = button.dataset.colour ? button.dataset.colour.toLowerCase() : '';
+      const isSelected = value === targetColour;
       button.classList.toggle('is-selected', isSelected);
     });
   }
@@ -1167,7 +1224,9 @@ export class Controls {
     this.highlightPaletteSwatch(nextColour);
 
     if (this.paletteButton) {
-      this.paletteButton.style.setProperty('--active-colour', nextColour);
+      const isRainbow = nextColour.toLowerCase() === 'rainbow';
+      this.paletteButton.style.setProperty('--active-colour', isRainbow ? RAINBOW_INDICATOR : nextColour);
+      this.paletteButton.classList.toggle('is-rainbow', isRainbow);
     }
 
     if (this.customColourInput && this.customColourInput.value !== nextColour) {
@@ -1187,10 +1246,7 @@ export class Controls {
     const normalisedKey = key === 'red-blue' ? 'phonics-lines' : key;
     const styleKey = PAGE_STYLE_DRAWERS[normalisedKey] ? normalisedKey : 'phonics-lines';
     this.userData.userSettings.selectedBackground = styleKey;
-    if (this.linesContext) {
-      const drawer = PAGE_STYLE_DRAWERS[styleKey] ?? clearBackground;
-      drawer(this.linesContext, CANVAS_WIDTH, CANVAS_HEIGHT);
-    }
+    this.drawBackground(styleKey);
 
     this.pageStyleButtons.forEach(button => {
       button.classList.toggle('is-selected', button.dataset.pageStyle === styleKey);
@@ -1213,6 +1269,16 @@ export class Controls {
     if (persist) {
       this.userData.saveToLocalStorage();
     }
+  }
+
+  drawBackground(styleKey = this.userData.userSettings.selectedBackground ?? DEFAULT_SETTINGS.selectedBackground) {
+    if (!this.linesContext) {
+      return;
+    }
+
+    const drawer = PAGE_STYLE_DRAWERS[styleKey] ?? clearBackground;
+    const zoom = this.currentZoom ?? 1;
+    drawer(this.linesContext, CANVAS_WIDTH, CANVAS_HEIGHT, zoom);
   }
 
   setPageColour(colour, persist = true) {
@@ -1240,13 +1306,9 @@ export class Controls {
   setZoom(value, persist = true) {
     const zoom = clamp(Number(value) || DEFAULT_SETTINGS.zoomLevel, 0.5, 3);
     this.userData.userSettings.zoomLevel = zoom;
-    if (this.writerContainer) {
-      this.writerContainer.style.setProperty('--zoom-level', String(zoom));
-    }
+    this.currentZoom = zoom;
 
-    if (this.writerBoard) {
-      this.writerBoard.style.setProperty('--zoom-level', String(zoom));
-    }
+    this.drawBackground();
 
     this.updateToolbarWidthFromBoard();
 
@@ -1263,10 +1325,20 @@ export class Controls {
       this.speedSlider.setAttribute('aria-valuenow', String(speed));
     }
 
+    if (this.speedSliderFullscreen && this.speedSliderFullscreen.value !== String(speed)) {
+      this.speedSliderFullscreen.value = String(speed);
+      this.speedSliderFullscreen.setAttribute('aria-valuenow', String(speed));
+    }
+
+    const formatted = Number(speed).toFixed(1);
+    const display = formatted.endsWith('.0') ? String(Number(formatted)) : formatted;
+
     if (this.speedValueLabel) {
-      const formatted = Number(speed).toFixed(1);
-      const display = formatted.endsWith('.0') ? String(Number(formatted)) : formatted;
       this.speedValueLabel.textContent = `${display}×`;
+    }
+
+    if (this.speedValueDisplay) {
+      this.speedValueDisplay.textContent = `${display}×`;
     }
     if (persist) {
       this.userData.saveToLocalStorage();
@@ -1484,11 +1556,26 @@ function clearBackground(ctx, width, height) {
   ctx.clearRect(0, 0, width, height);
 }
 
-function drawPhonicsLinesGuidelines(ctx, width, height) {
+function drawPhonicsLinesGuidelines(ctx, width, height, zoom = 1) {
   ctx.clearRect(0, 0, width, height);
 
+  const drawImage = image => {
+    if (!image) {
+      return;
+    }
+
+    const scale = Number.isFinite(zoom) && zoom > 0 ? zoom : 1;
+    const drawWidth = width * scale;
+    const drawHeight = height * scale;
+    const offsetX = (width - drawWidth) / 2;
+    const offsetY = (height - drawHeight) / 2;
+
+    ctx.clearRect(0, 0, width, height);
+    ctx.drawImage(image, offsetX, offsetY, drawWidth, drawHeight);
+  };
+
   if (phonicsLinesImage) {
-    ctx.drawImage(phonicsLinesImage, 0, 0, width, height);
+    drawImage(phonicsLinesImage);
     return;
   }
 
@@ -1506,10 +1593,6 @@ function drawPhonicsLinesGuidelines(ctx, width, height) {
   }
 
   phonicsLinesImagePromise.then(image => {
-    if (!image) {
-      return;
-    }
-    ctx.clearRect(0, 0, width, height);
-    ctx.drawImage(image, 0, 0, width, height);
+    drawImage(image);
   });
 }

--- a/js/teach.js
+++ b/js/teach.js
@@ -25,6 +25,7 @@ export class TeachController {
     this.previewContainer = previewContainer ?? null;
     this.previewToggleButton = previewToggleButton ?? null;
     this.hideLettersButton = hideLettersButton ?? null;
+    this.hideLettersLabelElement = this.hideLettersButton?.querySelector('[data-button-label]') ?? null;
     this.enableDefaultNextHandler = enableDefaultNextHandler;
 
     this.overlayContent = null;
@@ -35,7 +36,12 @@ export class TeachController {
     this.nextPointer = 0;
     this.isPreviewHidden = false;
     this.isHideMode = false;
-    this.hideLettersButtonInitialLabel = (this.hideLettersButton?.textContent ?? 'Show letters').trim();
+    const initialLabelSource =
+      this.hideLettersLabelElement?.textContent ??
+      this.hideLettersButton?.getAttribute('aria-label') ??
+      'Show letters';
+    this.hideLettersButtonInitialLabel = initialLabelSource.trim();
+    this.setHideLettersButtonText(this.hideLettersButtonInitialLabel);
     this.currentRawText = '';
     this.revealHistory = [];
     this.hiddenLettersPromptValue = '';
@@ -80,6 +86,23 @@ export class TeachController {
     this.setOverlayHidden(true);
     this.updateButtonStates();
     this.updatePreviewVisibility();
+  }
+
+  setHideLettersButtonText(label) {
+    if (!this.hideLettersButton) {
+      return;
+    }
+
+    const text = typeof label === 'string' ? label : '';
+
+    if (this.hideLettersLabelElement) {
+      this.hideLettersLabelElement.textContent = text;
+    } else {
+      this.hideLettersButton.textContent = text;
+    }
+
+    this.hideLettersButton.setAttribute('aria-label', text);
+    this.hideLettersButton.title = text;
   }
 
   handleTeach() {
@@ -233,7 +256,7 @@ export class TeachController {
     if (this.isHideMode === nextState) {
       if (!nextState && this.hideLettersButton) {
         const label = this.hideLettersButtonInitialLabel || 'Hide letters';
-        this.hideLettersButton.textContent = label;
+        this.setHideLettersButtonText(label);
         this.hideLettersButton.setAttribute('aria-pressed', 'false');
         this.hideLettersButton.classList.remove('is-active');
       }
@@ -251,7 +274,7 @@ export class TeachController {
 
     if (this.hideLettersButton) {
       const label = this.isHideMode ? 'Done hiding' : this.hideLettersButtonInitialLabel || 'Hide letters';
-      this.hideLettersButton.textContent = label;
+      this.setHideLettersButtonText(label);
       this.hideLettersButton.setAttribute('aria-pressed', this.isHideMode ? 'true' : 'false');
       this.hideLettersButton.classList.toggle('is-active', this.isHideMode);
     }
@@ -658,7 +681,7 @@ export class TeachController {
         this.setHideMode(false);
       }
       const label = this.hideLettersButtonInitialLabel || 'Show letters';
-      this.hideLettersButton.textContent = label;
+      this.setHideLettersButtonText(label);
       this.hideLettersButton.setAttribute('aria-pressed', 'false');
       this.hideLettersButton.classList.remove('is-active');
     }


### PR DESCRIPTION
## Summary
- restyle the fullscreen experience with icon buttons, slimmer side panels, and bottom sliders for pen size, speed, and colour selection
- move the rewrite control to the fullscreen toolbar and add twelve preset colours plus a rainbow gradient option in both palettes
- update zoom handling to scale only the background lines and add a rainbow pen mode while keeping accessibility text for the hide letters control

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3ec12ef7083318c9dbf7aefcc4582