### PR TITLE
Replace info icon with red pin

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1816,8 +1816,17 @@ body.is-fullscreen #toolbarBottom {
 }
 
 .info-panel-toggle__icon {
-  font-size: clamp(1.4rem, 2.4vw, 1.6rem);
-  font-family: "Comic Sans MS", "KG Primary", "Chalkboard SE", "Comic Neue", cursive;
+  display: inline-flex;
+  width: clamp(1.6rem, 2.6vw, 1.8rem);
+  height: clamp(1.6rem, 2.6vw, 1.8rem);
+  align-items: center;
+  justify-content: center;
+}
+
+.info-panel-toggle__pin {
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 .info-panel-toggle__label {

--- a/index.html
+++ b/index.html
@@ -69,7 +69,15 @@
       aria-label="Teach Handwriting information and feedback"
       title="Teach Handwriting information and feedback"
     >
-      <span aria-hidden="true" class="info-panel-toggle__icon">i</span>
+      <span aria-hidden="true" class="info-panel-toggle__icon">
+        <svg class="info-panel-toggle__pin" viewBox="0 0 24 24" focusable="false" role="img" aria-hidden="true">
+          <path
+            fill="#d7263d"
+            d="M12 2C8.134 2 5 5.134 5 9c0 5.387 7 13 7 13s7-7.613 7-13c0-3.866-3.134-7-7-7Zm0 10.5a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7Z"
+          />
+          <circle cx="12" cy="9" r="2" fill="#fff" opacity="0.65" />
+        </svg>
+      </span>
     </button>
 
     <div id="infoPanelBackdrop" class="info-panel-backdrop" hidden></div>


### PR DESCRIPTION
## Summary
- replace the info panel toggle text icon with an inline SVG red map pin
- update the toggle icon styles so the SVG scales and aligns within the button

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3fa87fae48331bb627ac1963e498e