### PR TITLE
Align fullscreen mode with requested layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -393,8 +393,8 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: clamp(8px, 2.2vw, 16px);
-  padding: clamp(8px, 1.8vw, 14px);
+  gap: clamp(6px, 1.6vw, 14px);
+  padding: clamp(6px, 1.4vw, 12px);
   border-radius: 20px;
   border: 2px solid #000000;
   background: rgba(255, 244, 213, 0.2);
@@ -411,8 +411,8 @@ body {
 }
 
 .side-panel__button {
-  width: 52px;
-  height: 52px;
+  width: 48px;
+  height: 48px;
 }
 
 .side-panel__button.is-active {
@@ -423,8 +423,8 @@ body {
 }
 
 .side-panel__button.btn-primary {
-  width: 68px;
-  height: 68px;
+  width: 60px;
+  height: 60px;
 }
 
 .side-panel__action {
@@ -584,18 +584,18 @@ body.is-fullscreen .main-container {
 }
 
 body.is-fullscreen .side-panel {
-  padding: clamp(6px, 1.4vw, 12px);
-  gap: clamp(6px, 1.6vw, 12px);
+  padding: clamp(4px, 1vw, 10px);
+  gap: clamp(4px, 1.2vw, 10px);
 }
 
 body.is-fullscreen .side-panel__button {
-  width: 48px;
-  height: 48px;
+  width: 44px;
+  height: 44px;
 }
 
 body.is-fullscreen .btn.icon.side-panel__button svg {
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
 }
 
 body.is-fullscreen .app-shell {
@@ -611,7 +611,7 @@ body.is-fullscreen .writer-container {
   border: 2px solid rgba(255, 255, 255, 0.2);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
   border-radius: 32px;
-  padding: clamp(20px, 4vh, 40px) clamp(24px, 6vw, 48px);
+  padding: clamp(16px, 3.6vh, 32px) clamp(20px, 5vw, 40px);
   width: 100%;
   max-width: none;
   min-height: 0;
@@ -620,7 +620,7 @@ body.is-fullscreen .writer-container {
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
-  gap: clamp(24px, 5vh, 40px);
+  gap: clamp(20px, 4.6vh, 36px);
   box-sizing: border-box;
 }
 
@@ -646,6 +646,12 @@ body.is-fullscreen .board-header {
   box-sizing: border-box;
 }
 
+body.is-fullscreen #boardRegion {
+  width: 100%;
+  max-width: none;
+  gap: clamp(16px, 3vw, 32px);
+}
+
 body.is-fullscreen .board-header__title {
   max-width: clamp(320px, 58%, 720px);
 }
@@ -660,6 +666,25 @@ body.is-fullscreen #boardDate {
 
 body.is-fullscreen #boardLessonTitle {
   margin-top: 0;
+}
+
+body.is-fullscreen .board-header {
+  color: #ffffff;
+}
+
+body.is-fullscreen .board-lesson-title,
+body.is-fullscreen #boardDate {
+  color: inherit;
+  text-shadow: 0 4px 12px rgba(10, 9, 3, 0.35);
+}
+
+body.is-fullscreen #boardDate:hover,
+body.is-fullscreen #boardDate:focus-visible {
+  color: #ffe6d5;
+}
+
+body.is-fullscreen #boardDate:active {
+  color: #ffe6d5;
 }
 
 body.is-fullscreen #retroTv {
@@ -861,7 +886,8 @@ body.board-controls-hidden #toolbarBottom {
   display: none;
   width: 100%;
   flex-direction: column;
-  gap: clamp(16px, 3vw, 24px);
+  align-items: center;
+  gap: clamp(14px, 2.6vw, 22px);
 }
 
 .fullscreen-toolbar__sliders {
@@ -869,15 +895,15 @@ body.board-controls-hidden #toolbarBottom {
   flex-wrap: wrap;
   align-items: center;
   justify-content: center;
-  gap: clamp(16px, 3vw, 28px);
+  gap: clamp(12px, 2.4vw, 20px);
 }
 
 .fullscreen-slider {
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
-  gap: 12px;
-  padding: 12px 16px;
+  gap: 10px;
+  padding: 10px 14px;
   border-radius: 18px;
   background: rgba(255, 244, 213, 0.55);
   border: 1px solid rgba(10, 9, 3, 0.12);
@@ -898,19 +924,21 @@ body.board-controls-hidden #toolbarBottom {
 }
 
 .fullscreen-slider .slider {
-  width: clamp(200px, 32vw, 360px);
+  width: clamp(180px, 30vw, 320px);
 }
 
 .fullscreen-toolbar__action {
-  width: 64px;
-  height: 64px;
+  width: 56px;
+  height: 56px;
 }
 
 .fullscreen-palette {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(44px, 1fr));
-  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(40px, 1fr));
+  gap: 10px;
   width: 100%;
+  max-width: min(100%, 600px);
+  margin: 0 auto;
 }
 
 .fullscreen-palette .swatch {
@@ -932,13 +960,13 @@ body.board-controls-hidden #toolbarBottom {
 }
 
 body.is-fullscreen #toolbarBottom {
-  padding: clamp(14px, 2.4vw, 22px);
+  padding: clamp(12px, 2.2vw, 20px);
 }
 
 body.is-fullscreen .bottom-toolbar__inner {
   flex-direction: column;
   align-items: stretch;
-  gap: clamp(16px, 3vw, 24px);
+  gap: clamp(14px, 2.4vw, 22px);
 }
 
 body.is-fullscreen .control-popover {
@@ -1761,8 +1789,8 @@ body.is-fullscreen #toolbarBottom {
   }
 
   .side-panel__button.btn-primary {
-    width: 64px;
-    height: 64px;
+    width: 60px;
+    height: 60px;
   }
 
   .control-popover {

--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@
       </section>
 
     <main class="main-container disable-select" role="main">
-      <div class="app-shell disable-select">
+      <div id="appShell" class="app-shell disable-select">
         <section
           id="toolbarTop"
           class="toolbar toolbar--top"
@@ -216,7 +216,7 @@
           </div>
         </section>
 
-        <div class="board-region">
+        <div id="boardRegion" class="board-region">
           <div id="boardHeader" class="board-header" role="presentation">
             <div class="board-header__title">
               <div

--- a/js/Controls.js
+++ b/js/Controls.js
@@ -45,6 +45,8 @@ export class Controls {
     this.userData = userData;
 
     this.writerContainer = document.getElementById('writerContainer');
+    this.appShell = document.getElementById('appShell');
+    this.boardRegion = document.getElementById('boardRegion');
     this.writerBoard = document.getElementById('writerBoard');
     this.rewriterCanvas = document.getElementById('writer');
     this.rewriterTraceCanvas = document.getElementById('writerTrace');
@@ -632,10 +634,38 @@ export class Controls {
   setupAuxiliaryButtons() {
     if (this.fullscreenButtons.length > 0) {
       const toggleFullscreen = () => {
-        if (document.fullscreenElement) {
-          document.exitFullscreen();
-        } else {
-          (this.writerContainer ?? document.documentElement).requestFullscreen().catch(() => {});
+        const activeElement = document.fullscreenElement ?? document.webkitFullscreenElement ?? null;
+        if (activeElement) {
+          if (typeof document.exitFullscreen === 'function') {
+            const exitResult = document.exitFullscreen();
+            if (exitResult?.catch) {
+              exitResult.catch(() => {});
+            }
+          } else if (typeof document.webkitExitFullscreen === 'function') {
+            document.webkitExitFullscreen();
+          }
+          return;
+        }
+
+        const target = this.getFullscreenTarget();
+        if (!target) {
+          return;
+        }
+
+        const request =
+          target.requestFullscreen?.bind(target) ??
+          target.webkitRequestFullscreen?.bind(target) ??
+          null;
+
+        if (typeof request === 'function') {
+          try {
+            const requestResult = request();
+            if (requestResult?.catch) {
+              requestResult.catch(() => {});
+            }
+          } catch (error) {
+            // Ignore inability to enter fullscreen.
+          }
         }
       };
 
@@ -809,10 +839,12 @@ export class Controls {
 
     const handleFullscreenChange = () => {
       const fullscreenElement = document.fullscreenElement ?? document.webkitFullscreenElement ?? null;
+      const target = this.getFullscreenTarget();
+      const isTargetFullscreen = fullscreenElement === target;
       const isWriterFullscreen = fullscreenElement === this.writerContainer;
       const isDocumentFullscreen =
         fullscreenElement === document.documentElement || fullscreenElement === document.body;
-      const isAppFullscreen = isWriterFullscreen || isDocumentFullscreen;
+      const isAppFullscreen = isTargetFullscreen || isWriterFullscreen || isDocumentFullscreen;
       const body = document.body;
 
       if (body) {
@@ -890,6 +922,26 @@ export class Controls {
     }
 
     this.toolbarBottom.style.setProperty('--board-width', `${rect.width}px`);
+  }
+
+  getFullscreenTarget() {
+    if (this.appShell) {
+      return this.appShell;
+    }
+
+    if (this.boardRegion) {
+      return this.boardRegion;
+    }
+
+    if (this.writerContainer) {
+      return this.writerContainer;
+    }
+
+    if (typeof document !== 'undefined') {
+      return document.documentElement;
+    }
+
+    return null;
   }
 
   setupCookieBanner() {
@@ -1419,15 +1471,24 @@ export class Controls {
       }
     }
 
-    if (this.writerContainer && typeof window !== 'undefined') {
-      try {
-        const styles = window.getComputedStyle(this.writerContainer);
-        const paddingBottom = parseFloat(styles.paddingBottom) || 0;
-        const gap = parseFloat(styles.rowGap || styles.gap) || 0;
-        offset += paddingBottom + gap;
-      } catch (error) {
-        // Ignore inability to read computed styles.
-      }
+    if (typeof window !== 'undefined') {
+      const containers = [this.getFullscreenTarget(), this.writerContainer].filter(
+        (element, index, array) => element && array.indexOf(element) === index
+      );
+
+      containers.forEach(element => {
+        if (!element) {
+          return;
+        }
+        try {
+          const styles = window.getComputedStyle(element);
+          const paddingBottom = parseFloat(styles.paddingBottom) || 0;
+          const gap = parseFloat(styles.rowGap || styles.gap) || 0;
+          offset += paddingBottom + gap;
+        } catch (error) {
+          // Ignore inability to read computed styles.
+        }
+      });
     }
 
     body.style.setProperty('--fullscreen-toolbar-offset', `${Math.max(offset, baseSpacing)}px`);


### PR DESCRIPTION
## Summary
- expand the fullscreen target to the full app shell so the board header and lesson details are visible
- streamline fullscreen controls and palettes with smaller sidebars, updated colors, and centered sliders
- adjust stylesheet to shrink control footprints and restyle the lesson title and date for the aerospace orange backdrop

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d3fc4d8460833191476ddf9e95bda8