### PR TITLE
Add liquid glass styling to interactive buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -416,10 +416,12 @@ body {
 }
 
 .side-panel__button.is-active {
-  background: #ffffff;
+  --glass-base: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, rgba(255, 255, 255, 0.78) 100%);
+  --glass-border-color: rgba(255, 255, 255, 0.8);
+  --glass-shadow: 0 18px 32px rgba(10, 9, 3, 0.24);
+  --glass-hover-shadow: 0 20px 36px rgba(10, 9, 3, 0.26);
+  --glass-inset-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.72), inset 0 -10px 18px rgba(255, 244, 213, 0.6);
   color: var(--color-smoky-black);
-  border-color: rgba(10, 9, 3, 0.28);
-  box-shadow: 0 14px 28px rgba(10, 9, 3, 0.22);
 }
 
 .side-panel__button.btn-primary {
@@ -444,6 +446,13 @@ body {
 }
 
 .side-panel .control-popover__toggle {
+  --glass-base: linear-gradient(180deg, rgba(255, 255, 255, 0.92) 0%, rgba(255, 255, 255, 0.7) 100%);
+  --glass-border-width: 2px;
+  --glass-border-color: rgba(255, 255, 255, 0.62);
+  --glass-shadow: 0 12px 26px rgba(10, 9, 3, 0.18);
+  --glass-hover-shadow: 0 16px 30px rgba(10, 9, 3, 0.22);
+  --glass-active-shadow: 0 10px 20px rgba(10, 9, 3, 0.2);
+  --glass-inset-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.68), inset 0 -10px 18px rgba(255, 244, 213, 0.55);
   width: clamp(64px, 16vw, 92px);
   min-height: clamp(76px, 18vw, 112px);
   padding: 12px;
@@ -452,17 +461,13 @@ body {
   align-items: center;
   gap: 6px;
   border-radius: 18px;
-  border: 2px solid rgba(10, 9, 3, 0.18);
-  background: rgba(255, 244, 213, 0.92);
-  box-shadow: 0 12px 22px rgba(10, 9, 3, 0.18);
   text-align: center;
 }
 
 .side-panel .control-popover__toggle:hover,
 .side-panel .control-popover__toggle:focus-visible,
 .side-panel .control-popover.is-open .control-popover__toggle {
-  border-color: rgba(10, 9, 3, 0.32);
-  box-shadow: 0 16px 28px rgba(10, 9, 3, 0.22);
+  --glass-border-color: rgba(255, 255, 255, 0.78);
 }
 
 .side-panel .control-popover__icon {
@@ -1182,22 +1187,216 @@ body.is-fullscreen .board-palette {
   box-shadow: 0 0 0 3px rgba(255, 130, 0, 0.2);
 }
 
-.teach-button {
+:is(
+    .teach-button,
+    .btn.icon,
+    .btn-primary,
+    .teach-preview__toggle,
+    .side-panel .control-popover__toggle,
+    #toolbarToggle
+  ) {
+  --glass-base: linear-gradient(180deg, rgba(255, 255, 255, 0.94) 0%, rgba(255, 255, 255, 0.72) 100%);
+  --glass-border-width: 2px;
+  --glass-border-color: rgba(255, 255, 255, 0.55);
+  --glass-shadow: 0 16px 32px rgba(10, 9, 3, 0.22);
+  --glass-hover-shadow: 0 20px 36px rgba(10, 9, 3, 0.26);
+  --glass-active-shadow: 0 12px 22px rgba(10, 9, 3, 0.22);
+  --glass-focus-ring: 0 0 0 0 rgba(255, 255, 255, 0);
+  --glass-inset-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.68), inset 0 -6px 12px rgba(255, 244, 213, 0.5);
+  --glass-blur: 12px;
   position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  border: var(--glass-border-width) solid var(--glass-border-color);
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.7) 0%, rgba(255, 255, 255, 0.28) 45%, rgba(255, 255, 255, 0.08) 100%),
+    var(--glass-base);
+  box-shadow: var(--glass-focus-ring), var(--glass-shadow), var(--glass-inset-shadow);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.2s ease, filter 0.2s ease, color 0.2s ease,
+    background 0.28s ease;
+}
+
+:is(
+    .teach-button,
+    .btn.icon,
+    .btn-primary,
+    .teach-preview__toggle,
+    .side-panel .control-popover__toggle,
+    #toolbarToggle
+  )::before,
+:is(
+    .teach-button,
+    .btn.icon,
+    .btn-primary,
+    .teach-preview__toggle,
+    .side-panel .control-popover__toggle,
+    #toolbarToggle
+  )::after {
+  content: "";
+  position: absolute;
+  pointer-events: none;
+  border-radius: inherit;
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+:is(
+    .teach-button,
+    .btn.icon,
+    .btn-primary,
+    .teach-preview__toggle,
+    .side-panel .control-popover__toggle,
+    #toolbarToggle
+  )::before {
+  inset: 0;
+  background: radial-gradient(
+    120% 120% at 18% 12%,
+    rgba(255, 255, 255, 0.9) 0%,
+    rgba(255, 255, 255, 0.4) 45%,
+    rgba(255, 255, 255, 0) 70%
+  );
+  opacity: 0.68;
+}
+
+:is(
+    .teach-button,
+    .btn.icon,
+    .btn-primary,
+    .teach-preview__toggle,
+    .side-panel .control-popover__toggle,
+    #toolbarToggle
+  )::after {
+  bottom: -35%;
+  left: 50%;
+  width: 140%;
+  height: 70%;
+  transform: translateX(-50%);
+  background: radial-gradient(60% 60% at 50% 50%, rgba(255, 255, 255, 0.45) 0%, rgba(255, 255, 255, 0) 70%);
+  filter: blur(10px);
+  opacity: 0.5;
+}
+
+:is(
+    .teach-button,
+    .btn.icon,
+    .btn-primary,
+    .teach-preview__toggle,
+    .side-panel .control-popover__toggle,
+    #toolbarToggle
+  ):hover {
+  --glass-shadow: var(--glass-hover-shadow);
+  transform: translateY(-1px);
+}
+
+:is(
+    .teach-button,
+    .btn.icon,
+    .btn-primary,
+    .teach-preview__toggle,
+    .side-panel .control-popover__toggle,
+    #toolbarToggle
+  ):focus-visible {
+  --glass-shadow: var(--glass-hover-shadow);
+  --glass-focus-ring: 0 0 0 3px rgba(255, 255, 255, 0.45);
+  transform: translateY(-1px);
+}
+
+:is(
+    .teach-button,
+    .btn.icon,
+    .btn-primary,
+    .teach-preview__toggle,
+    .side-panel .control-popover__toggle,
+    #toolbarToggle
+  ):hover::before,
+:is(
+    .teach-button,
+    .btn.icon,
+    .btn-primary,
+    .teach-preview__toggle,
+    .side-panel .control-popover__toggle,
+    #toolbarToggle
+  ):focus-visible::before {
+  opacity: 0.82;
+  transform: translateY(-2px);
+}
+
+:is(
+    .teach-button,
+    .btn.icon,
+    .btn-primary,
+    .teach-preview__toggle,
+    .side-panel .control-popover__toggle,
+    #toolbarToggle
+  ):hover::after,
+:is(
+    .teach-button,
+    .btn.icon,
+    .btn-primary,
+    .teach-preview__toggle,
+    .side-panel .control-popover__toggle,
+    #toolbarToggle
+  ):focus-visible::after {
+  opacity: 0.66;
+  transform: translate(-50%, -8px);
+}
+
+:is(
+    .teach-button,
+    .btn.icon,
+    .btn-primary,
+    .teach-preview__toggle,
+    .side-panel .control-popover__toggle,
+    #toolbarToggle
+  ):active {
+  --glass-shadow: var(--glass-active-shadow);
+  --glass-focus-ring: 0 0 0 0 rgba(255, 255, 255, 0);
+  transform: translateY(0);
+}
+
+:is(
+    .teach-button,
+    .btn.icon,
+    .btn-primary,
+    .teach-preview__toggle,
+    .side-panel .control-popover__toggle,
+    #toolbarToggle
+  ):active::before {
+  opacity: 0.55;
+  transform: translateY(-1px);
+}
+
+:is(
+    .teach-button,
+    .btn.icon,
+    .btn-primary,
+    .teach-preview__toggle,
+    .side-panel .control-popover__toggle,
+    #toolbarToggle
+  ):active::after {
+  opacity: 0.55;
+  transform: translate(-50%, -4px);
+}
+
+.teach-button {
+  --glass-base: linear-gradient(180deg, rgba(255, 130, 0, 0.96) 0%, rgba(215, 38, 61, 0.9) 100%);
+  --glass-border-width: 2px;
+  --glass-border-color: rgba(255, 229, 210, 0.8);
+  --glass-shadow: 0 18px 36px rgba(10, 9, 3, 0.25);
+  --glass-hover-shadow: 0 22px 38px rgba(10, 9, 3, 0.28);
+  --glass-active-shadow: 0 12px 22px rgba(10, 9, 3, 0.24);
+  --glass-inset-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65), inset 0 -10px 18px rgba(255, 81, 0, 0.45);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 6px;
   padding: 10px 18px;
   border-radius: 999px;
-  border: 2px solid rgba(10, 9, 3, 0.1);
-  background: linear-gradient(180deg, var(--color-ut-orange) 0%, var(--color-aerospace-orange) 100%);
   color: #fff;
   font-weight: 600;
   font-size: 1rem;
   cursor: pointer;
-  box-shadow: 0 6px 14px rgba(10, 9, 3, 0.18);
-  transition: transform 0.12s ease, box-shadow 0.12s ease, filter 0.18s ease;
   min-width: 92px;
   appearance: none;
 }
@@ -1205,47 +1404,53 @@ body.is-fullscreen .board-palette {
 .teach-button:hover,
 .teach-button:focus-visible {
   outline: none;
-  transform: translateY(-1px);
-  box-shadow: 0 10px 20px rgba(10, 9, 3, 0.22);
   filter: brightness(1.05);
 }
 
 .side-panel__action.teach-button {
-  background: #ffffff;
+  --glass-base: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, rgba(255, 255, 255, 0.72) 100%);
+  --glass-border-color: rgba(255, 255, 255, 0.68);
+  --glass-shadow: 0 14px 28px rgba(10, 9, 3, 0.2);
+  --glass-hover-shadow: 0 18px 32px rgba(10, 9, 3, 0.24);
+  --glass-active-shadow: 0 10px 20px rgba(10, 9, 3, 0.22);
+  --glass-inset-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.72), inset 0 -8px 16px rgba(255, 244, 213, 0.6);
   color: var(--color-smoky-black);
-  border-color: rgba(10, 9, 3, 0.18);
-  box-shadow: 0 10px 20px rgba(10, 9, 3, 0.2);
   padding: 12px 20px;
 }
 
 .side-panel__action.teach-button.is-active {
-  background: linear-gradient(180deg, var(--color-ut-orange) 0%, var(--color-aerospace-orange) 100%);
+  --glass-base: linear-gradient(180deg, rgba(255, 130, 0, 0.96) 0%, rgba(215, 38, 61, 0.9) 100%);
+  --glass-border-color: rgba(255, 229, 210, 0.82);
+  --glass-inset-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65), inset 0 -10px 18px rgba(255, 81, 0, 0.45);
   color: #fff;
-  border-color: rgba(10, 9, 3, 0.18);
 }
 
 .side-panel__action.teach-button:hover,
 .side-panel__action.teach-button:focus-visible {
-  background: #ffffff;
-  color: var(--color-smoky-black);
-  border-color: rgba(10, 9, 3, 0.28);
-  filter: none;
+  --glass-border-color: rgba(255, 255, 255, 0.78);
+  color: inherit;
 }
 
 .side-panel__action.teach-button:active {
-  background: #ffffff;
-  color: var(--color-smoky-black);
+  color: inherit;
 }
 
 .teach-button:active {
-  transform: translateY(0);
-  box-shadow: 0 4px 10px rgba(10, 9, 3, 0.2);
+  filter: brightness(1);
 }
 
 .teach-button:disabled {
+  --glass-shadow: none;
+  --glass-hover-shadow: none;
+  --glass-inset-shadow: none;
   cursor: not-allowed;
   opacity: 0.6;
   box-shadow: none;
+}
+
+.teach-button:disabled::before,
+.teach-button:disabled::after {
+  opacity: 0.25;
 }
 
 .teach-button__arrow {
@@ -1262,32 +1467,41 @@ body.is-fullscreen .board-palette {
 }
 
 .teach-preview__toggle {
+  --glass-base: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, rgba(255, 255, 255, 0.75) 100%);
+  --glass-border-width: 1.5px;
+  --glass-border-color: rgba(255, 255, 255, 0.65);
+  --glass-shadow: 0 12px 22px rgba(10, 9, 3, 0.18);
+  --glass-hover-shadow: 0 16px 26px rgba(10, 9, 3, 0.2);
+  --glass-active-shadow: 0 10px 18px rgba(10, 9, 3, 0.18);
+  --glass-inset-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7), inset 0 -8px 16px rgba(255, 244, 213, 0.55);
   padding: 6px 12px;
   border-radius: 10px;
-  border: 1px solid rgba(10, 9, 3, 0.18);
-  background: rgba(255, 255, 255, 0.85);
   font-family: inherit;
   font-weight: 600;
   font-size: 0.9rem;
   color: var(--color-smoky-black);
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.12s ease, transform 0.12s ease;
 }
 
 .teach-preview__toggle:hover,
 .teach-preview__toggle:focus-visible {
   outline: none;
-  transform: translateY(-1px);
-  box-shadow: 0 6px 14px rgba(10, 9, 3, 0.16);
 }
 
 .teach-preview__toggle:disabled {
+  --glass-shadow: none;
+  --glass-hover-shadow: none;
+  --glass-inset-shadow: none;
   cursor: not-allowed;
   opacity: 0.55;
-  background: rgba(255, 255, 255, 0.7);
   color: rgba(10, 9, 3, 0.65);
   transform: none;
   box-shadow: none;
+}
+
+.teach-preview__toggle:disabled::before,
+.teach-preview__toggle:disabled::after {
+  opacity: 0.3;
 }
 
 .teach-preview {
@@ -1479,19 +1693,21 @@ body.is-fullscreen .board-palette {
   color: #111111;
 }
 .btn.icon {
-  position: relative;
+  --glass-base: linear-gradient(180deg, rgba(255, 255, 255, 0.94) 0%, rgba(255, 255, 255, 0.68) 100%);
+  --glass-border-width: 2px;
+  --glass-border-color: rgba(255, 255, 255, 0.6);
+  --glass-shadow: 0 16px 30px rgba(10, 9, 3, 0.22);
+  --glass-hover-shadow: 0 20px 36px rgba(10, 9, 3, 0.28);
+  --glass-active-shadow: 0 12px 22px rgba(10, 9, 3, 0.24);
+  --glass-inset-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7), inset 0 -8px 14px rgba(255, 244, 213, 0.45);
   width: 52px;
   height: 52px;
   border-radius: 12px;
-  border: 2px solid rgba(10, 9, 3, 0.15);
-  background: #ffffff;
   color: var(--color-smoky-black);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  box-shadow: 0 6px 14px rgba(10, 9, 3, 0.18);
-  transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
   padding: 0;
 }
 
@@ -1503,21 +1719,21 @@ body.is-fullscreen .board-palette {
 
 .btn.icon:hover,
 .btn.icon:focus-visible {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 20px rgba(10, 9, 3, 0.24);
-  outline: none;
-  background: var(--color-smoky-black);
+  --glass-base: linear-gradient(180deg, rgba(29, 41, 81, 0.92) 0%, rgba(10, 9, 3, 0.88) 100%);
+  --glass-border-color: rgba(255, 255, 255, 0.78);
   color: #ffffff;
-  border-color: #ffffff;
+  outline: none;
 }
 
 .btn.icon:active {
-  transform: translateY(0);
-  box-shadow: 0 4px 8px rgba(10, 9, 3, 0.24);
+  --glass-base: linear-gradient(180deg, rgba(29, 41, 81, 0.88) 0%, rgba(10, 9, 3, 0.82) 100%);
 }
 
 .btn.icon.is-disabled,
 .btn.icon:disabled {
+  --glass-shadow: none;
+  --glass-hover-shadow: none;
+  --glass-inset-shadow: none;
   opacity: 0.45;
   cursor: not-allowed;
   pointer-events: none;
@@ -1532,6 +1748,13 @@ body.is-fullscreen .board-palette {
 }
 
 #toolbarToggle {
+  --glass-base: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, rgba(255, 255, 255, 0.72) 100%);
+  --glass-border-width: 2px;
+  --glass-border-color: rgba(255, 255, 255, 0.62);
+  --glass-shadow: 0 18px 30px rgba(10, 9, 3, 0.18);
+  --glass-hover-shadow: 0 22px 34px rgba(10, 9, 3, 0.24);
+  --glass-active-shadow: 0 14px 22px rgba(10, 9, 3, 0.22);
+  --glass-inset-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.68), inset 0 -10px 18px rgba(255, 244, 213, 0.55);
   display: none;
   position: absolute;
   top: 12px;
@@ -1540,15 +1763,12 @@ body.is-fullscreen .board-palette {
   width: 72px;
   height: 44px;
   border-radius: 999px;
-  border: 2px solid rgba(10, 9, 3, 0.15);
-  background: #ffffff;
   color: var(--color-smoky-black);
-  box-shadow: 0 10px 22px rgba(10, 9, 3, 0.18);
   cursor: pointer;
   align-items: center;
   justify-content: center;
   padding: 0;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, color 0.2s ease, border-color 0.2s ease;
   z-index: 2;
 }
 
@@ -1561,6 +1781,14 @@ body.is-fullscreen .board-palette {
 }
 
 #toolbarToggle:hover,
+#toolbarToggle:focus-visible {
+  --glass-base: linear-gradient(180deg, rgba(255, 130, 0, 0.92) 0%, rgba(215, 38, 61, 0.88) 100%);
+  --glass-border-color: rgba(255, 229, 210, 0.82);
+  color: #ffffff;
+  outline: none;
+}
+
+#toolbarToggle:hover,
 body.is-fullscreen #toolbarBottom {
   margin-top: auto;
   margin-bottom: clamp(16px, 4vw, 28px);
@@ -1569,28 +1797,32 @@ body.is-fullscreen #toolbarBottom {
   padding: clamp(12px, 2.4vw, 20px) calc(var(--fullscreen-horizontal-gutter) / 2);
 }
 
-.btn.icon.is-active {
-  background: var(--color-smoky-black);
+.btn.icon.is-active:not(.side-panel__button) {
+  --glass-base: linear-gradient(180deg, rgba(29, 41, 81, 0.96) 0%, rgba(10, 9, 3, 0.92) 100%);
+  --glass-border-color: rgba(255, 255, 255, 0.85);
+  --glass-shadow: 0 18px 32px rgba(255, 201, 41, 0.35);
   color: #ffffff;
-  box-shadow: 0 6px 16px rgba(255, 201, 41, 0.35);
-  border-color: #ffffff;
 }
 
 .btn-primary {
+  --glass-base: linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, rgba(255, 255, 255, 0.75) 100%);
+  --glass-border-width: 3px;
+  --glass-border-color: rgba(255, 255, 255, 0.78);
+  --glass-shadow: 0 24px 40px rgba(255, 130, 0, 0.35);
+  --glass-hover-shadow: 0 26px 46px rgba(255, 130, 0, 0.4);
+  --glass-active-shadow: 0 18px 30px rgba(255, 130, 0, 0.32);
+  --glass-inset-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75), inset 0 -12px 22px rgba(255, 130, 0, 0.35);
   width: 68px;
   height: 68px;
   border-radius: 18px;
-  background: #ffffff;
   color: var(--color-smoky-black);
-  border: 3px solid var(--color-smoky-black);
-  box-shadow: 0 18px 28px rgba(255, 130, 0, 0.3);
 }
 
 .btn-primary:hover,
 .btn-primary:focus-visible {
-  background: var(--color-smoky-black);
+  --glass-base: linear-gradient(180deg, rgba(29, 41, 81, 0.92) 0%, rgba(10, 9, 3, 0.88) 100%);
+  --glass-border-color: rgba(255, 255, 255, 0.85);
   color: #ffffff;
-  border-color: #ffffff;
 }
 
 .slider-control {


### PR DESCRIPTION
## Summary
- add a shared glassmorphism effect layer for major UI buttons using CSS custom properties and pseudo-element highlights
- restyle primary teach buttons and icon buttons with the new sheen across hover, active, and disabled states
- refresh preview toggles, popover toggles, and the fullscreen toolbar toggle to match the liquid glass treatment

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d414478fec8331aaa47daf5140bc8a