### PR TITLE
Adjust fullscreen palette width

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1114,12 +1114,11 @@ body.is-fullscreen .fullscreen-palette {
   justify-content: center;
   align-items: center;
   gap: clamp(4px, 1vw, 8px);
-  width: auto;
-  max-width: none;
+  width: max-content;
+  max-width: 100%;
   overflow-x: auto;
   padding-bottom: 4px;
-  flex: 1 1 clamp(360px, 48vw, 720px);
-  min-width: clamp(360px, 48vw, 720px);
+  flex: 0 0 auto;
 }
 
 body.is-fullscreen .fullscreen-palette .swatch {


### PR DESCRIPTION
## Summary
- prevent the fullscreen palette from stretching beyond the colour swatches by disabling flex growth
- allow the palette to size itself to its contents so the background hugs the swatch row

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d48971c12483319606e4ced1fd0a32