### PR TITLE
Add fullscreen lesson title flyout and draggable header

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -415,6 +415,21 @@ body {
   height: 48px;
 }
 
+.side-panel__flyout {
+  position: relative;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.side-panel__flyout > .side-panel__button {
+  flex: 0 0 auto;
+}
+
+.lesson-title-flyout {
+  display: none;
+}
+
 .side-panel__button.is-active {
   background: #ffffff;
   color: var(--color-smoky-black);
@@ -619,6 +634,37 @@ body {
   opacity: 0;
 }
 
+body.is-fullscreen .board-lesson-title {
+  pointer-events: auto;
+  position: absolute;
+  top: clamp(16px, 6vh, 96px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(255, 244, 213, 0.94);
+  border: 2px solid rgba(10, 9, 3, 0.12);
+  border-radius: 22px;
+  padding: clamp(10px, 1.8vh, 18px) clamp(20px, 3vw, 36px);
+  box-shadow: 0 18px 36px rgba(10, 9, 3, 0.24);
+  max-width: min(calc(100vw - clamp(140px, 24vw, 320px)), 840px);
+  width: auto;
+  cursor: grab;
+  user-select: none;
+  -webkit-user-select: none;
+  z-index: 5;
+  transition: box-shadow 0.2s ease;
+  touch-action: none;
+}
+
+body.is-fullscreen .board-lesson-title:focus-visible {
+  outline: 3px solid rgba(255, 130, 0, 0.7);
+  outline-offset: 4px;
+}
+
+body.is-fullscreen .board-lesson-title.is-dragging {
+  cursor: grabbing;
+  box-shadow: 0 22px 44px rgba(10, 9, 3, 0.32);
+}
+
 body.is-fullscreen {
   align-items: stretch;
   background: var(--color-aerospace-orange);
@@ -647,6 +693,59 @@ body.is-fullscreen .side-panel {
 body.is-fullscreen .side-panel__button {
   width: 44px;
   height: 44px;
+}
+
+body.is-fullscreen .lesson-title-flyout {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  position: absolute;
+  top: 50%;
+  right: calc(100% + clamp(12px, 2.4vw, 22px));
+  transform: translate3d(clamp(16px, 2vw, 24px), -50%, 0);
+  opacity: 0;
+  pointer-events: none;
+  background: rgba(255, 244, 213, 0.94);
+  border: 2px solid rgba(10, 9, 3, 0.16);
+  border-radius: 18px;
+  box-shadow: 0 16px 30px rgba(10, 9, 3, 0.22);
+  padding: 12px 16px;
+  min-width: clamp(220px, 24vw, 320px);
+  z-index: 20;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+body.is-fullscreen .lesson-title-flyout.is-open {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate3d(0, -50%, 0);
+}
+
+body.is-fullscreen .lesson-title-flyout__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-smoky-black);
+}
+
+body.is-fullscreen .lesson-title-flyout__input {
+  flex: 1;
+  min-width: 0;
+  border-radius: 12px;
+  border: 2px solid rgba(10, 9, 3, 0.18);
+  background: #ffffff;
+  font-family: inherit;
+  font-size: 1rem;
+  padding: 10px 14px;
+  color: var(--color-smoky-black);
+  box-shadow: inset 0 1px 2px rgba(10, 9, 3, 0.08);
+}
+
+body.is-fullscreen .lesson-title-flyout__input:focus {
+  outline: none;
+  border-color: rgba(255, 130, 0, 0.7);
+  box-shadow: inset 0 1px 2px rgba(10, 9, 3, 0.08), 0 0 0 3px rgba(255, 130, 0, 0.18);
 }
 
 body.is-fullscreen .btn.icon.side-panel__button svg {
@@ -725,6 +824,10 @@ body.is-fullscreen .board-header {
 }
 
 body.is-fullscreen #boardRegion {
+  position: relative;
+}
+
+body.is-fullscreen #boardRegion {
   width: 100%;
   max-width: none;
   gap: clamp(10px, 2vh, 20px);
@@ -739,6 +842,7 @@ body.is-fullscreen .board-header__title {
   max-width: none;
   flex: 1 1 auto;
   justify-content: center;
+  min-height: clamp(64px, 10vh, 128px);
 }
 
 body.is-fullscreen .board-header__date {

--- a/index.html
+++ b/index.html
@@ -403,16 +403,38 @@ main
               </div>
 
               <aside class="side-panel side-panel--right" aria-label="Playback controls">
-                <button
-                  class="btn icon side-panel__button"
-                  id="btnLessonTitlePrompt"
-                  type="button"
-                  aria-label="Lesson title"
-                  title="Lesson title"
-                >
-                  <svg aria-hidden="true"><use href="assets/icons.svg#title"></use></svg>
-                  <span class="visually-hidden">Lesson title</span>
-                </button>
+                <div class="side-panel__flyout">
+                  <button
+                    class="btn icon side-panel__button"
+                    id="btnLessonTitlePrompt"
+                    type="button"
+                    aria-label="Lesson title"
+                    title="Lesson title"
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                    aria-controls="lessonTitleFlyout"
+                  >
+                    <svg aria-hidden="true"><use href="assets/icons.svg#title"></use></svg>
+                    <span class="visually-hidden">Lesson title</span>
+                  </button>
+                  <div
+                    id="lessonTitleFlyout"
+                    class="lesson-title-flyout"
+                    role="presentation"
+                    aria-hidden="true"
+                  >
+                    <label class="lesson-title-flyout__label" for="lessonTitleFlyoutInput"
+                      >Lesson title</label
+                    >
+                    <input
+                      id="lessonTitleFlyoutInput"
+                      class="lesson-title-flyout__input"
+                      type="text"
+                      placeholder="Put the lesson title"
+                      autocomplete="off"
+                    />
+                  </div>
+                </div>
                 <button
                   class="btn icon side-panel__button"
                   id="btnPracticeTextPrompt"

--- a/js/Controls.js
+++ b/js/Controls.js
@@ -148,7 +148,6 @@ export class Controls {
     this.boardHeader = document.getElementById('boardHeader');
     this.lessonTitleInput = document.getElementById('inputLessonTitle');
     this.lessonTitleSubmitButton = document.getElementById('btnLessonTitleApply');
-
     this.storage = getLocalStorage();
     this.toolbarLayoutVersion = this.getStorageItem?.('ui.toolbarLayoutVersion') ?? null;
     this.currentZoom = this.userData?.userSettings?.zoomLevel ?? DEFAULT_SETTINGS.zoomLevel;
@@ -165,6 +164,10 @@ export class Controls {
     this.handleBoardHeaderResize = () => {
       this.queueBoardHeaderResize();
     };
+    this.isFullscreenActive = false;
+    this.lessonTitlePosition = null;
+    this.lessonTitlePointerId = null;
+    this.lessonTitlePointerOffset = { x: 0, y: 0 };
 
     this.migrateSettings();
     this.initialiseCanvases();
@@ -181,6 +184,7 @@ export class Controls {
     this.setupCookieBanner();
     this.setupDateDisplay();
     this.setupLessonTitle();
+    this.setupLessonTitleDrag();
     this.setupBoardHeaderScaling();
     this.setupFullscreenBehaviour();
     this.setupToolbarWidthSync();
@@ -866,6 +870,7 @@ export class Controls {
 
       applyCollapsedState(isAppFullscreen && wasCollapsed);
       this.updateToolbarWidthFromBoard();
+      this.applyFullscreenLessonTitleState(isAppFullscreen);
     };
 
     if (this.toolbarToggleButton) {
@@ -1075,6 +1080,184 @@ export class Controls {
     });
   }
 
+  setupLessonTitleDrag() {
+    if (!this.boardLessonTitle || !this.boardRegion) {
+      return;
+    }
+
+    const element = this.boardLessonTitle;
+    const container = this.boardRegion;
+
+    const updateFromPointer = (clientX, clientY) => {
+      const containerRect = container.getBoundingClientRect();
+      const desiredLeft = clientX - containerRect.left - this.lessonTitlePointerOffset.x;
+      const desiredTop = clientY - containerRect.top - this.lessonTitlePointerOffset.y;
+      this.setLessonTitleFloatingPosition(desiredLeft, desiredTop);
+    };
+
+    const handlePointerDown = event => {
+      if (!this.isFullscreenActive || event.button === 1 || event.button === 2) {
+        return;
+      }
+
+      this.lessonTitlePointerId = event.pointerId;
+      const rect = element.getBoundingClientRect();
+      this.lessonTitlePointerOffset = {
+        x: event.clientX - rect.left,
+        y: event.clientY - rect.top
+      };
+      element.classList.add('is-dragging');
+
+      try {
+        element.setPointerCapture?.(event.pointerId);
+      } catch (error) {
+        // Ignore inability to capture pointer.
+      }
+
+      updateFromPointer(event.clientX, event.clientY);
+      event.preventDefault();
+    };
+
+    const handlePointerMove = event => {
+      if (!this.isFullscreenActive) {
+        return;
+      }
+
+      if (this.lessonTitlePointerId === null || event.pointerId !== this.lessonTitlePointerId) {
+        return;
+      }
+
+      updateFromPointer(event.clientX, event.clientY);
+      event.preventDefault();
+    };
+
+    const endDrag = event => {
+      if (this.lessonTitlePointerId === null || (event && event.pointerId !== this.lessonTitlePointerId)) {
+        return;
+      }
+
+      const pointerId = this.lessonTitlePointerId;
+      this.lessonTitlePointerId = null;
+      this.lessonTitlePointerOffset = { x: 0, y: 0 };
+      element.classList.remove('is-dragging');
+
+      if (pointerId !== null) {
+        try {
+          element.releasePointerCapture?.(pointerId);
+        } catch (error) {
+          // Ignore inability to release pointer.
+        }
+      }
+    };
+
+    element.addEventListener('pointerdown', handlePointerDown);
+    element.addEventListener('pointermove', handlePointerMove);
+    element.addEventListener('pointerup', endDrag);
+    element.addEventListener('pointercancel', endDrag);
+    element.addEventListener('lostpointercapture', () => {
+      this.lessonTitlePointerId = null;
+      this.lessonTitlePointerOffset = { x: 0, y: 0 };
+      element.classList.remove('is-dragging');
+    });
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('resize', () => {
+        if (this.isFullscreenActive) {
+          this.ensureLessonTitleFloatingPosition();
+        }
+      });
+    }
+  }
+
+  ensureLessonTitleFloatingPosition() {
+    if (!this.boardLessonTitle || !this.boardRegion) {
+      return;
+    }
+
+    const containerRect = this.boardRegion.getBoundingClientRect();
+    const containerWidth = containerRect.width;
+    const containerHeight = containerRect.height;
+
+    if (containerWidth === 0 || containerHeight === 0) {
+      return;
+    }
+
+    const elementWidth = this.boardLessonTitle.offsetWidth;
+    const elementHeight = this.boardLessonTitle.offsetHeight;
+    const maxLeft = Math.max(containerWidth - elementWidth, 0);
+    const maxTop = Math.max(containerHeight - elementHeight, 0);
+
+    let left = typeof this.lessonTitlePosition?.left === 'number'
+      ? this.lessonTitlePosition.left
+      : Math.max((containerWidth - elementWidth) / 2, 0);
+    let top = typeof this.lessonTitlePosition?.top === 'number'
+      ? this.lessonTitlePosition.top
+      : clamp(containerHeight * 0.06, 16, maxTop);
+
+    left = clamp(left, 0, maxLeft);
+    top = clamp(top, 0, maxTop);
+
+    this.boardLessonTitle.style.left = `${left}px`;
+    this.boardLessonTitle.style.top = `${top}px`;
+    this.boardLessonTitle.style.transform = 'translate3d(0, 0, 0)';
+    this.lessonTitlePosition = { left, top };
+  }
+
+  setLessonTitleFloatingPosition(left, top) {
+    if (!this.boardLessonTitle || !this.boardRegion) {
+      return;
+    }
+
+    const containerRect = this.boardRegion.getBoundingClientRect();
+    const elementWidth = this.boardLessonTitle.offsetWidth;
+    const elementHeight = this.boardLessonTitle.offsetHeight;
+    const maxLeft = Math.max(containerRect.width - elementWidth, 0);
+    const maxTop = Math.max(containerRect.height - elementHeight, 0);
+
+    const clampedLeft = clamp(left, 0, maxLeft);
+    const clampedTop = clamp(top, 0, maxTop);
+
+    this.boardLessonTitle.style.left = `${clampedLeft}px`;
+    this.boardLessonTitle.style.top = `${clampedTop}px`;
+    this.boardLessonTitle.style.transform = 'translate3d(0, 0, 0)';
+    this.lessonTitlePosition = { left: clampedLeft, top: clampedTop };
+  }
+
+  applyFullscreenLessonTitleState(isFullscreen) {
+    this.isFullscreenActive = isFullscreen;
+
+    if (!this.boardLessonTitle) {
+      return;
+    }
+
+    if (!isFullscreen) {
+      this.lessonTitlePosition = null;
+      const pointerId = this.lessonTitlePointerId;
+      this.lessonTitlePointerId = null;
+      this.lessonTitlePointerOffset = { x: 0, y: 0 };
+      if (pointerId !== null) {
+        try {
+          this.boardLessonTitle.releasePointerCapture?.(pointerId);
+        } catch (error) {
+          // Ignore inability to release pointer.
+        }
+      }
+      this.boardLessonTitle.style.left = '';
+      this.boardLessonTitle.style.top = '';
+      this.boardLessonTitle.style.transform = '';
+      this.boardLessonTitle.classList.remove('is-dragging');
+      return;
+    }
+
+    if (typeof window !== 'undefined') {
+      window.requestAnimationFrame(() => {
+        this.ensureLessonTitleFloatingPosition();
+      });
+    } else {
+      this.ensureLessonTitleFloatingPosition();
+    }
+  }
+
   setupBoardHeaderScaling() {
     if (!this.boardHeader) {
       return;
@@ -1200,6 +1383,16 @@ export class Controls {
     }
 
     this.queueBoardHeaderResize();
+
+    if (this.isFullscreenActive) {
+      if (typeof window !== 'undefined') {
+        window.requestAnimationFrame(() => {
+          this.ensureLessonTitleFloatingPosition();
+        });
+      } else {
+        this.ensureLessonTitleFloatingPosition();
+      }
+    }
   }
 
   applyToolbarLayoutVersion() {


### PR DESCRIPTION
## Summary
- add a fullscreen-only flyout input next to the lesson title button so the title can be edited inline
- style the fullscreen toolbar/title area for the new flyout and floating title badge
- allow the lesson title to float above the board in fullscreen and be repositioned by dragging

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d488e37b808331976a161928783a52