### PR TITLE
Refresh fullscreen orange theme

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4,12 +4,23 @@
 
 :root {
   --color-smoky-black: #0a0903;
-  --color-aerospace-orange: #ffa500;
+  --color-aerospace-orange: #ff8c1a;
+  --color-orange-bright: #ffb347;
+  --color-orange-soft: #fff1d9;
+  --color-orange-bright-rgb: 255, 179, 71;
+  --color-orange-soft-rgb: 255, 241, 217;
+  --color-orange-glass: rgba(255, 214, 170, 0.28);
+  --color-orange-border: rgba(191, 78, 0, 0.42);
   --color-aerospace-blue: #1d2951;
   --color-ut-orange: #ff8200;
   --color-sunglow: #ffc929;
   --color-crosstik: #fff4d5;
-  --color-board-surround: #ff4f14;
+  --color-board-surround: linear-gradient(
+    150deg,
+    rgba(255, 140, 26, 0.94) 0%,
+    rgba(var(--color-orange-bright-rgb), 0.92) 48%,
+    rgba(var(--color-orange-soft-rgb), 0.88) 100%
+  );
   --app-fixed-width: min(100vw, 1440px);
   --board-fixed-width: min(100vw, 1200px);
   --control-button-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.94) 0%, rgba(255, 255, 255, 0.72) 100%);
@@ -87,9 +98,13 @@ body {
 }
 
 .toolbar--top {
-  background: rgba(255, 244, 213, 0.85);
+  background: linear-gradient(
+    150deg,
+    rgba(var(--color-orange-soft-rgb), 0.9) 0%,
+    rgba(var(--color-orange-bright-rgb), 0.82) 100%
+  );
   border-radius: 24px;
-  border: 2px solid #000000;
+  border: 2px solid var(--color-orange-border);
   box-shadow: 0 18px 36px rgba(10, 9, 3, 0.2);
   color: var(--color-smoky-black);
   padding: clamp(20px, 2.6vw, 28px) clamp(24px, 3vw, 36px);
@@ -126,7 +141,11 @@ body {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  background: rgba(255, 255, 255, 0.78);
+  background: linear-gradient(
+    160deg,
+    rgba(var(--color-orange-soft-rgb), 0.9) 0%,
+    rgba(var(--color-orange-bright-rgb), 0.82) 100%
+  );
   border-radius: 16px;
   padding: 16px 18px 18px;
   box-shadow: inset 0 0 0 1px rgba(10, 9, 3, 0.08);
@@ -215,7 +234,11 @@ body {
   gap: clamp(20px, 2.6vw, 36px);
   padding: clamp(20px, 3vw, 36px);
   border-radius: 32px;
-  background: rgba(255, 255, 255, 0.04);
+  background: linear-gradient(
+    150deg,
+    rgba(var(--color-orange-soft-rgb), 0.6) 0%,
+    rgba(var(--color-orange-bright-rgb), 0.46) 100%
+  );
   box-shadow: 0 24px 48px rgba(10, 9, 3, 0.24);
   box-sizing: border-box;
 }
@@ -228,12 +251,14 @@ body {
   gap: clamp(16px, 2.4vw, 24px);
   touch-action: none;
   background: var(--color-board-surround);
+  border: 1px solid var(--color-orange-border);
   border-radius: 28px;
   padding: clamp(14px, 2.6vw, 24px);
   overflow: visible;
   width: 100%;
   max-width: 100%;
   flex: 1;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
 }
 
 .board-frame {
@@ -241,9 +266,11 @@ body {
   width: 100%;
   max-width: var(--board-fixed-width);
   border-radius: 28px;
-  border: 5px solid #000000;
-  background: #ffffff;
-  box-shadow: 0 22px 44px rgba(10, 9, 3, 0.24);
+  border: 5px solid rgba(42, 24, 0, 0.9);
+  background: linear-gradient(180deg, var(--color-orange-soft) 0%, #fff3de 100%);
+  box-shadow:
+    0 22px 44px rgba(10, 9, 3, 0.24),
+    0 0 0 3px rgba(var(--color-orange-bright-rgb), 0.2);
   overflow: hidden;
 }
 
@@ -299,8 +326,12 @@ body {
   top: 50%;
   transform: translateY(-50%);
   border-radius: 22px;
-  border: 2px solid #000000;
-  background: rgba(255, 244, 213, 0.95);
+  border: 2px solid var(--color-orange-border);
+  background: linear-gradient(
+    180deg,
+    rgba(var(--color-orange-soft-rgb), 0.96) 0%,
+    rgba(var(--color-orange-bright-rgb), 0.82) 100%
+  );
   box-shadow: 0 16px 28px rgba(10, 9, 3, 0.22);
   display: inline-flex;
   align-items: center;
@@ -375,7 +406,7 @@ body {
 }
 
 .board-fab__segment--redo {
-  background: rgba(255, 244, 213, 0.95);
+  background: rgba(var(--color-orange-soft-rgb), 0.95);
   color: var(--color-smoky-black);
   border-bottom: 1px solid rgba(10, 9, 3, 0.18);
 }
@@ -400,10 +431,10 @@ body {
   gap: clamp(4px, 1.2vw, 12px);
   padding: clamp(6px, 1vw, 10px);
   border-radius: 18px;
-  border: 2px solid rgba(0, 0, 0, 0.75);
-  background: rgba(255, 244, 213, 0.16);
+  border: 2px solid var(--color-orange-border);
+  background: var(--color-orange-glass);
   box-shadow: 0 12px 22px rgba(10, 9, 3, 0.18);
-  backdrop-filter: blur(4px);
+  backdrop-filter: blur(6px);
   flex: 0 0 auto;
   align-self: stretch;
   max-height: 100%;
@@ -749,6 +780,8 @@ body.is-fullscreen .main-container {
 body.is-fullscreen .side-panel {
   padding: clamp(4px, 1vw, 10px);
   gap: clamp(4px, 1.2vw, 10px);
+  border-color: rgba(var(--color-orange-soft-rgb), 0.55);
+  background: rgba(var(--color-orange-bright-rgb), 0.24);
 }
 
 body.is-fullscreen .side-panel__button {
@@ -766,13 +799,21 @@ body.is-fullscreen .app-shell {
   max-width: none;
   height: 100%;
   padding: clamp(12px, 2.5vw, 24px);
+  background: linear-gradient(
+    150deg,
+    rgba(var(--color-orange-bright-rgb), 0.42) 0%,
+    rgba(255, 148, 34, 0.55) 100%
+  );
+  border: 1px solid rgba(var(--color-orange-soft-rgb), 0.4);
   border-radius: 42px;
 }
 
 body.is-fullscreen .writer-container {
   background: var(--color-board-surround);
-  border: 2px solid rgba(255, 255, 255, 0.2);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  border: 2px solid rgba(var(--color-orange-soft-rgb), 0.55);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.24),
+    0 26px 48px rgba(10, 9, 3, 0.25);
   border-radius: 32px;
   padding: clamp(16px, 3vh, 26px) calc(var(--fullscreen-horizontal-gutter) / 2);
   width: 100%;
@@ -999,9 +1040,14 @@ body.is-fullscreen #timerProgress {
   justify-content: center;
   width: min(var(--board-width, var(--board-fixed-width)), 100%);
   margin: clamp(4px, 1vw, 10px) auto 0;
-  background: rgba(255, 244, 213, 0.18);
+  background: linear-gradient(
+    145deg,
+    rgba(var(--color-orange-soft-rgb), 0.92) 0%,
+    rgba(var(--color-orange-bright-rgb), 0.78) 100%
+  );
+  border: 2px solid var(--color-orange-border);
   border-radius: 22px;
-  box-shadow: 0 10px 20px rgba(10, 9, 3, 0.16);
+  box-shadow: 0 10px 20px rgba(10, 9, 3, 0.18);
   color: var(--color-smoky-black);
   padding: clamp(16px, 2.6vw, 24px);
   transition: opacity 0.3s ease, transform 0.3s ease;


### PR DESCRIPTION
## Summary
- retune the primary orange variable and add supporting palette tokens for consistent styling
- refresh writer board, toolbars, side panels, and bottom toolbar surfaces with cohesive orange gradients
- update fullscreen container borders and shadows to complement the new orange palette

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d4d13404208331b67e692ffaad30a0