### PR TITLE
Improve cookie banner to stop blocking controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3004,3 +3004,109 @@ body.info-panel-open {
     transition: none;
   }
 }
+.cookie-popup {
+  position: fixed;
+  inset: auto 1.5rem 1.5rem auto;
+  max-width: min(360px, calc(100vw - 2rem));
+  width: 100%;
+  display: none;
+  z-index: 10000;
+  pointer-events: none;
+}
+
+.cookie-popup.is-visible {
+  display: block;
+}
+
+.cookie-popup__card {
+  pointer-events: auto;
+  background: #ffffff;
+  color: #1a1a1a;
+  border-radius: 16px;
+  padding: 20px 22px;
+  box-shadow: 0 18px 36px rgba(10, 9, 3, 0.22);
+  border: 1px solid rgba(10, 9, 3, 0.08);
+  font-family: 'ABeeZee', Verdana, Geneva, Tahoma, sans-serif;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.cookie-popup__title {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.cookie-popup__message {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: #2d2d2d;
+}
+
+.cookie-popup__link {
+  color: var(--color-aerospace-blue);
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+.cookie-popup__actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.cookie-popup__button {
+  appearance: none;
+  border: 1px solid rgba(10, 9, 3, 0.16);
+  border-radius: 999px;
+  padding: 8px 18px;
+  background: rgba(255, 255, 255, 0.92);
+  color: #1a1a1a;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background-color 0.18s ease;
+}
+
+.cookie-popup__button:hover,
+.cookie-popup__button:focus-visible {
+  outline: none;
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(10, 9, 3, 0.16);
+}
+
+.cookie-popup__button--primary {
+  background: var(--color-aerospace-blue);
+  color: #ffffff;
+  border-color: rgba(29, 41, 81, 0.3);
+}
+
+.cookie-popup__button--primary:hover,
+.cookie-popup__button--primary:focus-visible {
+  background: rgba(29, 41, 81, 0.92);
+}
+
+.cookie-popup__button:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+@media (max-width: 480px) {
+  .cookie-popup {
+    inset: auto 1rem 1rem 1rem;
+    max-width: none;
+  }
+
+  .cookie-popup__actions {
+    justify-content: stretch;
+  }
+
+  .cookie-popup__button {
+    flex: 1 1 140px;
+    text-align: center;
+  }
+}
+

--- a/index.html
+++ b/index.html
@@ -674,16 +674,28 @@ main
       </div>
     </div>
 
-    <div id="cookiePopup" style="display: none; position: fixed; inset: 0; background: rgba(0, 0, 0, 0.6); justify-content: center; align-items: center; z-index: 10000;">
-      <div style="background: #fff; max-width: 500px; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.2);">
-        <h3 style="margin-top: 0;">We use cookies</h3>
-        <p>
+    <div
+      id="cookiePopup"
+      class="cookie-popup"
+      role="dialog"
+      aria-modal="false"
+      aria-live="polite"
+      aria-labelledby="cookiePopupTitle"
+      hidden
+    >
+      <div class="cookie-popup__card">
+        <h3 class="cookie-popup__title" id="cookiePopupTitle">We use cookies</h3>
+        <p class="cookie-popup__message">
           We use cookies to improve your experience and analyse traffic using Google Analytics. Read our
-          <a href="https://handwritingrepeater.app/privacy-policy.html" target="_blank" rel="noreferrer">Privacy Policy</a>.
+          <a class="cookie-popup__link" href="https://handwritingrepeater.app/privacy-policy.html" target="_blank" rel="noreferrer"
+            >Privacy Policy</a
+          >.
         </p>
-        <div style="margin-top: 20px; text-align: right;">
-          <button class="box-button" id="cookieRejectButton" type="button" style="padding: 5px 15px;">Reject</button>
-          <button class="box-button" id="cookieAcceptButton" type="button" style="padding: 5px 15px;">Accept</button>
+        <div class="cookie-popup__actions">
+          <button class="cookie-popup__button" id="cookieRejectButton" type="button">Reject</button>
+          <button class="cookie-popup__button cookie-popup__button--primary" id="cookieAcceptButton" type="button">
+            Accept
+          </button>
         </div>
       </div>
     </div>

--- a/js/Controls.js
+++ b/js/Controls.js
@@ -1003,7 +1003,7 @@ main
     if (consent === 'accepted') {
       this.loadAnalytics();
     } else {
-      this.cookiePopup.style.display = 'flex';
+      this.showCookieBanner();
     }
   }
 
@@ -2130,15 +2130,25 @@ main
   }
 
   showCookieBanner() {
-    if (this.cookiePopup) {
-      this.cookiePopup.style.display = 'flex';
+    if (!this.cookiePopup) {
+      return;
+    }
+
+    this.cookiePopup.hidden = false;
+    this.cookiePopup.classList.add('is-visible');
+
+    if (typeof window !== 'undefined') {
+      window.requestAnimationFrame(() => {
+        this.cookieAcceptButton?.focus();
+      });
     }
   }
 
   handleCookieConsent(accepted) {
     this.setCookie('cookie_consent', accepted ? 'accepted' : 'rejected', 365);
     if (this.cookiePopup) {
-      this.cookiePopup.style.display = 'none';
+      this.cookiePopup.classList.remove('is-visible');
+      this.cookiePopup.hidden = true;
     }
     if (accepted) {
       this.loadAnalytics();


### PR DESCRIPTION
## Summary
- replace the full-screen cookie overlay with a compact, non-blocking dialog component
- add dedicated styles and focus handling so the cookie banner no longer prevents toolbar interaction while keeping consent controls accessible

## Testing
- browser_container.run_playwright_script (verify cookie popup can appear without blocking buttons and hides after accepting)


------
https://chatgpt.com/codex/tasks/task_e_68d51688844c8331a379663b4a403c1f