### PR TITLE
Restore aerospace orange board background

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -15,12 +15,7 @@
   --color-ut-orange: #ff8200;
   --color-sunglow: #ffc929;
   --color-crosstik: #fff4d5;
-  --color-board-surround: linear-gradient(
-    150deg,
-    rgba(255, 140, 26, 0.94) 0%,
-    rgba(var(--color-orange-bright-rgb), 0.92) 48%,
-    rgba(var(--color-orange-soft-rgb), 0.88) 100%
-  );
+  --color-board-surround: var(--color-aerospace-orange);
   --app-fixed-width: min(100vw, 1440px);
   --board-fixed-width: min(100vw, 1200px);
   --control-button-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.94) 0%, rgba(255, 255, 255, 0.72) 100%);
@@ -252,27 +247,25 @@ body {
   gap: clamp(16px, 2.4vw, 24px);
   touch-action: none;
   background: var(--color-board-surround);
-  border: 1px solid var(--color-orange-border);
-  border-radius: 28px;
+  border: none;
+  border-radius: 0;
   padding: clamp(14px, 2.6vw, 24px);
   overflow: visible;
   width: 100%;
   max-width: 100%;
   flex: 1;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
+  box-shadow: none;
 }
 
 .board-frame {
   position: relative;
   width: 100%;
   max-width: var(--board-fixed-width);
-  border-radius: 28px;
-  border: 5px solid rgba(42, 24, 0, 0.9);
-  background: linear-gradient(180deg, var(--color-orange-soft) 0%, #fff3de 100%);
-  box-shadow:
-    0 22px 44px rgba(10, 9, 3, 0.24),
-    0 0 0 3px rgba(var(--color-orange-bright-rgb), 0.2);
-  overflow: hidden;
+  border-radius: 0;
+  border: none;
+  background: transparent;
+  box-shadow: none;
+  overflow: visible;
 }
 
 .writer-board {
@@ -800,22 +793,16 @@ body.is-fullscreen .app-shell {
   max-width: none;
   height: 100%;
   padding: clamp(12px, 2.5vw, 24px);
-  background: linear-gradient(
-    150deg,
-    rgba(var(--color-orange-bright-rgb), 0.42) 0%,
-    rgba(255, 148, 34, 0.55) 100%
-  );
-  border: 1px solid rgba(var(--color-orange-soft-rgb), 0.4);
-  border-radius: 42px;
+  background: var(--color-board-surround);
+  border: none;
+  border-radius: 0;
 }
 
 body.is-fullscreen .writer-container {
   background: var(--color-board-surround);
-  border: 2px solid rgba(var(--color-orange-soft-rgb), 0.55);
-  box-shadow:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.24),
-    0 26px 48px rgba(10, 9, 3, 0.25);
-  border-radius: 32px;
+  border: none;
+  box-shadow: none;
+  border-radius: 0;
   padding: clamp(16px, 3vh, 26px) calc(var(--fullscreen-horizontal-gutter) / 2);
   width: 100%;
   max-width: none;


### PR DESCRIPTION
## Summary
- set the board surround color variable to the solid aerospace orange brand tone
- remove gradient, border, and shadow styling from the main writer container and board frame
- align fullscreen shell and board surfaces with the solid aerospace orange background and no borders

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d51dec4fc88331995f5d5b2a88b558