### PR TITLE
Remove backgrounds from bottom toolbar controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1029,14 +1029,10 @@ body.is-fullscreen #timerProgress {
   justify-content: center;
   width: min(var(--board-width, var(--board-fixed-width)), 100%);
   margin: clamp(4px, 1vw, 10px) auto 0;
-  background: linear-gradient(
-    145deg,
-    rgba(var(--color-orange-soft-rgb), 0.92) 0%,
-    rgba(var(--color-orange-bright-rgb), 0.78) 100%
-  );
-  border: 2px solid var(--color-orange-border);
+  background: transparent;
+  border: none;
   border-radius: 22px;
-  box-shadow: 0 10px 20px rgba(10, 9, 3, 0.18);
+  box-shadow: none;
   color: var(--color-smoky-black);
   padding: clamp(16px, 2.6vw, 24px);
   transition: opacity 0.3s ease, transform 0.3s ease;
@@ -1190,7 +1186,7 @@ body.board-controls-hidden #toolbarBottom {
 }
 
 .board-slider {
-  background: rgba(255, 244, 213, 0.75);
+  background: transparent;
 }
 
 .fullscreen-slider {
@@ -1200,9 +1196,9 @@ body.board-controls-hidden #toolbarBottom {
   gap: 10px;
   padding: 10px 14px;
   border-radius: 18px;
-  background: rgba(255, 244, 213, 0.55);
-  border: 1px solid rgba(10, 9, 3, 0.12);
-  box-shadow: 0 10px 20px rgba(10, 9, 3, 0.18);
+  background: transparent;
+  border: none;
+  box-shadow: none;
 }
 
 .fullscreen-slider__label {


### PR DESCRIPTION
## Summary
- remove the gradient background from the bottom toolbar so colours and sliders sit on a transparent base
- clear the slider container backgrounds in both standard and fullscreen modes for a flat appearance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5300ff54c8331894be35e6771fdc7