### PR TITLE
Replace phonics line background with SVG asset

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2250,7 +2250,7 @@ body.is-fullscreen #toolbarBottom {
 
 .style-preview.style-phonics-lines {
   /* Keep in sync with PHONICS_LINES_ASSET_PATH in js/Controls.js */
-  background-image: url("../assets/icons/Phonics lines.png");
+  background-image: url("../assets/icons/Phonics lines.svg");
   background-repeat: no-repeat;
   background-size: cover;
   background-position: center;

--- a/js/Controls.js
+++ b/js/Controls.js
@@ -32,7 +32,7 @@ const PEN_COLOUR_SWATCHES = [
 
 const RAINBOW_INDICATOR = 'conic-gradient(from 0deg, #ff004d, #ffa500, #ffee00, #00d084, #1e4dd8, #7f3f98, #ff004d)';
 
-const PHONICS_LINES_ASSET_PATH = 'icons/Phonics lines.png';
+const PHONICS_LINES_ASSET_PATH = 'icons/Phonics lines.svg';
 const PHONICS_LINES_IMAGE_SRC = getAssetUrl(PHONICS_LINES_ASSET_PATH);
 let phonicsLinesImage = null;
 let phonicsLinesImagePromise = null;


### PR DESCRIPTION
## Summary
- update the phonics line preview background to use the SVG asset
- align the phonics background loader with the new SVG path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5314bbbbc8331a4ad201b482848a8