### PR TITLE
Add eraser drawing mode with adjustable size

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3148,6 +3148,16 @@ body.info-panel-open {
   height: 32px;
 }
 
+body.is-eraser #writerContainer,
+body.is-eraser #writerContainer canvas {
+  cursor: crosshair;
+}
+
+#btnEraserSize {
+  width: 96px;
+  flex: 0 0 auto;
+}
+
 .board-header {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- add an eraser mode toggle with adjustable width that stores dedicated eraser segments and clears the pen indicator when active
- update drawing routines and replay handling to render erasing with destination-out blending and reset composite operations afterwards
- style the eraser state with a crosshair cursor and surface the compact size slider while erasing

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d53ee3f20483319ea99f067c62457d