### PR TITLE
Add practice text preview controls and reveal flyout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2922,6 +2922,252 @@ body.info-panel-open {
   background: #f5ac00;
 }
 
+.practice-preview {
+  max-width: min(960px, calc(100% - 3rem));
+  margin: 1.25rem auto 1rem;
+  padding: 0.85rem 1.25rem;
+  background: rgba(13, 18, 32, 0.82);
+  border-radius: 20px;
+  box-shadow: 0 16px 30px rgba(7, 11, 21, 0.35);
+  backdrop-filter: blur(6px);
+  color: #f5f7fa;
+}
+
+.practice-preview[hidden] {
+  display: none;
+}
+
+.practice-preview__scroll {
+  max-height: 6.5rem;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-bottom: 0.25rem;
+}
+
+.practice-preview__scroll::-webkit-scrollbar {
+  height: 6px;
+}
+
+.practice-preview__scroll::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.28);
+  border-radius: 999px;
+}
+
+.practice-preview__scroll::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+}
+
+.practice-preview__letters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: clamp(1.1rem, 1.8vw, 1.45rem);
+  letter-spacing: 0.04em;
+}
+
+.practice-preview__letters br {
+  flex-basis: 100%;
+  height: 0;
+}
+
+.practice-preview__letter {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.25rem;
+  min-height: 2.5rem;
+  padding: 0.4rem 0.65rem;
+  border-radius: 14px;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.14);
+  color: inherit;
+  transition: background 0.25s ease, color 0.25s ease, transform 0.25s ease, opacity 0.3s ease;
+  position: relative;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+}
+
+.practice-preview__letter.is-hidden {
+  opacity: 0;
+  transform: scale(0.7);
+  box-shadow: none;
+}
+
+.practice-preview__letter.is-active {
+  background: #ffb300;
+  color: #231f20;
+  box-shadow: 0 14px 26px rgba(255, 179, 0, 0.35);
+}
+
+.practice-preview__letter.is-animating {
+  animation: practice-letter-pop 260ms ease;
+}
+
+.practice-preview__letter--space {
+  min-width: 1.6rem;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(245, 247, 250, 0.45);
+  font-weight: 500;
+}
+
+.practice-preview__break {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.8rem;
+  padding: 0.35rem;
+  border-radius: 10px;
+  font-size: 0.9rem;
+  color: rgba(245, 247, 250, 0.7);
+  background: rgba(255, 255, 255, 0.12);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+}
+
+@keyframes practice-letter-pop {
+  0% {
+    transform: scale(0.65);
+    opacity: 0.2;
+  }
+  60% {
+    transform: scale(1.15);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.reveal-flyout {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: min(340px, calc(100vw - 2.5rem));
+  background: #1d2230;
+  color: #f5f7fa;
+  border-radius: 18px;
+  padding: 1.1rem 1.25rem 1rem;
+  box-shadow: 0 18px 38px rgba(10, 14, 26, 0.45);
+  z-index: 120;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.reveal-flyout[hidden] {
+  display: none;
+}
+
+.reveal-flyout::before {
+  content: '';
+  position: absolute;
+  top: -12px;
+  left: 32px;
+  width: 0;
+  height: 0;
+  border-left: 12px solid transparent;
+  border-right: 12px solid transparent;
+  border-bottom: 12px solid #1d2230;
+  filter: drop-shadow(0 -2px 4px rgba(10, 14, 26, 0.2));
+}
+
+.reveal-flyout__form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.reveal-flyout__label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.7);
+  font-weight: 700;
+}
+
+.reveal-flyout__input {
+  width: 100%;
+  border-radius: 12px;
+  border: none;
+  padding: 0.65rem 0.85rem;
+  font-size: 1rem;
+  font-family: inherit;
+  color: #111;
+  background: #fff;
+  box-shadow: inset 0 0 0 1px rgba(17, 17, 17, 0.08);
+}
+
+.reveal-flyout__input:focus {
+  outline: 3px solid #ffb300;
+  outline-offset: 0;
+}
+
+.reveal-flyout__hint {
+  font-size: 0.8rem;
+  line-height: 1.4;
+  color: rgba(245, 247, 250, 0.7);
+  margin: -0.35rem 0 0;
+}
+
+.reveal-flyout__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.65rem;
+}
+
+.reveal-flyout__button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1.35rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.18);
+  color: #f5f7fa;
+  transition: background 0.25s ease, transform 0.25s ease, color 0.25s ease;
+}
+
+.reveal-flyout__button:hover,
+.reveal-flyout__button:focus-visible {
+  background: rgba(255, 255, 255, 0.28);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.reveal-flyout__button:active {
+  transform: translateY(0);
+}
+
+.reveal-flyout__button--primary {
+  background: #ffb300;
+  color: #231f20;
+}
+
+.reveal-flyout__button--primary:hover,
+.reveal-flyout__button--primary:focus-visible {
+  background: #ffca3a;
+}
+
+.reveal-flyout__button--primary:active {
+  background: #f5ac00;
+}
+
+@media (max-width: 720px) {
+  .practice-preview {
+    max-width: calc(100% - 1.5rem);
+    padding: 0.75rem 1rem;
+  }
+
+  .practice-preview__letter {
+    min-width: 1.9rem;
+    min-height: 2.2rem;
+  }
+
+  .reveal-flyout {
+    width: min(92vw, 320px);
+  }
+}
+
 @media (max-width: 640px) {
   .practice-strip {
     width: min(100%, calc(100% - 1.25rem));
@@ -2978,8 +3224,14 @@ body.info-panel-open {
 
   .practice-strip,
   .practice-strip__backdrop,
-  .practice-strip__button {
+  .practice-strip__button,
+  .practice-preview__letter,
+  .reveal-flyout__button {
     transition: none;
+  }
+
+  .practice-preview__letter.is-animating {
+    animation: none;
   }
 }
 .cookie-popup {

--- a/index.html
+++ b/index.html
@@ -240,6 +240,18 @@ main
     </div>
   </section>
 
+  <section
+    id="practicePreview"
+    class="practice-preview"
+    aria-label="Practice preview"
+    aria-live="polite"
+    hidden
+  >
+    <div class="practice-preview__scroll">
+      <div id="practicePreviewLetters" class="practice-preview__letters"></div>
+    </div>
+  </section>
+
   <footer id="bottomBar" class="bottom-bar" aria-label="Pen controls">
     <input id="penColour" type="color" aria-label="Pen colour" />
     <input id="penSize" type="range" min="1" max="60" value="8" aria-label="Pen size" />
@@ -272,6 +284,38 @@ main
         <div class="practice-strip__actions">
           <button class="practice-strip__button practice-strip__button--primary" type="submit">Apply</button>
           <button class="practice-strip__button" type="button" id="practiceStripCancel">Cancel</button>
+        </div>
+      </form>
+    </section>
+
+    <section
+      id="revealLettersFlyout"
+      class="reveal-flyout"
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby="revealLettersLabel"
+      hidden
+    >
+      <form class="reveal-flyout__form" id="revealLettersForm">
+        <label class="reveal-flyout__label" id="revealLettersLabel" for="revealLettersInput"
+          >Letters to hide</label
+        >
+        <input
+          id="revealLettersInput"
+          class="reveal-flyout__input"
+          type="text"
+          name="hiddenLetters"
+          inputmode="text"
+          autocomplete="off"
+          spellcheck="false"
+          aria-describedby="revealLettersHint"
+        />
+        <p class="reveal-flyout__hint" id="revealLettersHint">
+          Enter letters to start hidden. Characters are case-insensitive.
+        </p>
+        <div class="reveal-flyout__actions">
+          <button class="reveal-flyout__button reveal-flyout__button--primary" type="submit">Apply</button>
+          <button class="reveal-flyout__button" type="button" id="revealLettersCancel">Cancel</button>
         </div>
       </form>
     </section>


### PR DESCRIPTION
## Summary
- add a dedicated practice preview strip and hidden-letter flyout controls to the layout
- implement practice text state management, navigation, and letter reveal logic driven by the toolbar buttons
- style the new preview strip and flyout to match the existing interface

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d54a0ed8308331b3a7f4585aa873c2