### PR TITLE
Add background selector with persistent dotted pattern

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -619,6 +619,18 @@ body {
   pointer-events: auto;
 }
 
+#writerPage.bg-white,
+#writerPage.bg-dotted {
+  background-color: #fff;
+}
+
+#writerPage.bg-dotted {
+  background-repeat: repeat;
+  background-size: auto 24px;
+  background-position: left top;
+  image-rendering: crisp-edges;
+}
+
 
 .board-region {
   display: flex;
@@ -2121,6 +2133,37 @@ body.is-fullscreen #toolbarBottom {
   font-size: 1rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
+  color: var(--color-sunglow);
+}
+
+.background-options {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.background-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.background-option input[type='radio'] {
+  accent-color: var(--color-sunglow);
+}
+
+.background-option__label {
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+}
+
+.background-option.is-selected {
+  background: rgba(var(--color-orange-soft-rgb), 0.32);
   color: var(--color-sunglow);
 }
 


### PR DESCRIPTION
## Summary
- add CSS background classes for the writer canvas including a dotted baseline pattern
- provide a background selection popover that persists the chosen option in localStorage
- regenerate the dotted pattern on resize and clear the page canvas fill to reveal the CSS backgrounds

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d556eb61e88331803e8766e7f01807