### PR TITLE
Implement fullscreen controls and draggable stopwatch panel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -743,8 +743,8 @@ body {
 
 body.is-fullscreen {
   align-items: stretch;
-  background: #ff4500;
-  --color-board-surround: #ff4500;
+  background: #ff4f14;
+  --color-board-surround: #ff4f14;
   --fullscreen-horizontal-gutter: clamp(96px, 16vw, 220px);
 }
 
@@ -3491,9 +3491,44 @@ canvas {
 
 .board-lesson-title.is-floating,
 .board-date.is-floating,
-#stopwatchPanel.is-floating,
 .board-lesson-title.is-dragging,
-.board-date.is-dragging,
-#stopwatchPanel.is-dragging {
+.board-date.is-dragging {
   position: absolute;
+}
+
+#stopwatchPanel {
+  position: fixed;
+  top: 24px;
+  left: 24px;
+  display: block;
+  padding: 14px 18px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.96);
+  border: 2px solid rgba(10, 9, 3, 0.12);
+  box-shadow: 0 18px 36px rgba(10, 9, 3, 0.28);
+  color: var(--color-smoky-black);
+  min-width: clamp(180px, 28vw, 320px);
+  max-width: min(360px, 90vw);
+  font-size: 1rem;
+  line-height: 1.4;
+  pointer-events: auto;
+  touch-action: none;
+  user-select: none;
+  z-index: 4200;
+  cursor: grab;
+  transform: translate3d(0, 0, 0);
+}
+
+#stopwatchPanel[hidden] {
+  display: none !important;
+}
+
+#stopwatchPanel.is-floating,
+#stopwatchPanel.is-dragging {
+  position: fixed;
+}
+
+#stopwatchPanel.is-dragging {
+  cursor: grabbing;
+  box-shadow: 0 22px 48px rgba(10, 9, 3, 0.32);
 }


### PR DESCRIPTION
## Summary
- hook the fullscreen buttons up to toggle the main app container and keep toolbar UI in sync when the display mode changes
- add a draggable stopwatch panel that clamps to the viewport and persists its position between sessions
- refresh fullscreen styling by switching to the new red-orange background and providing fixed styling for the stopwatch overlay

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d557225db883319b50ba80aebe84a8