### PR TITLE
Improve accessibility and keyboard flows

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -43,6 +43,17 @@ body {
   --fullscreen-toolbar-offset: 0px;
 }
 
+button:focus-visible,
+[role="button"]:focus-visible {
+  outline: 3px solid rgba(29, 41, 81, 0.85);
+  outline-offset: 3px;
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.55);
+}
+
+button:focus {
+  outline: none;
+}
+
 .title-container {
   position: relative;
   width: 100%;

--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@ main
                 required
               ></textarea>
             </div>
-            <button class="feedback-submit" type="submit">Send Email</button>
+            <button class="feedback-submit" type="submit" aria-label="Send email feedback">Send Email</button>
           </form>
         </section>
       </div>
@@ -213,18 +213,18 @@ main
   </nav>
 
   <section id="lessonToolsRight" class="toolbar toolbar--right" aria-label="Lesson tools">
-    <button id="btnLessonTitlePrompt" class="toolbar__button" type="button">Lesson Title</button>
-    <button id="btnPracticeTextPrompt" class="toolbar__button" type="button">Practice Text</button>
-    <button id="btnRevealLettersPrompt" class="toolbar__button" type="button">Reveal Letters</button>
-    <button id="btnDeletePracticeText" class="toolbar__button" type="button">Delete Text</button>
+    <button id="btnLessonTitlePrompt" class="toolbar__button" type="button" aria-label="Edit lesson title">Lesson Title</button>
+    <button id="btnPracticeTextPrompt" class="toolbar__button" type="button" aria-label="Edit practice text">Practice Text</button>
+    <button id="btnRevealLettersPrompt" class="toolbar__button" type="button" aria-label="Adjust letters to reveal">Reveal Letters</button>
+    <button id="btnDeletePracticeText" class="toolbar__button" type="button" aria-label="Delete practice text">Delete Text</button>
     <button id="btnPrevLetter" class="toolbar__button" type="button" aria-label="Previous letter">
       <svg aria-hidden="true"><use href="assets/icons.svg#arrow-left"></use></svg>
     </button>
     <button id="btnNextLetter" class="toolbar__button" type="button" aria-label="Next letter">
       <svg aria-hidden="true"><use href="assets/icons.svg#arrow-right"></use></svg>
     </button>
-    <button id="btnUploadCursor" class="toolbar__button" type="button">Upload Cursor</button>
-    <button id="btnResetCursor" class="toolbar__button" type="button">Reset Cursor</button>
+    <button id="btnUploadCursor" class="toolbar__button" type="button" aria-label="Upload custom cursor">Upload Cursor</button>
+    <button id="btnResetCursor" class="toolbar__button" type="button" aria-label="Reset cursor to default">Reset Cursor</button>
     <button id="btnFullscreenRight" class="toolbar__button" type="button" aria-label="Enter fullscreen">
       <svg aria-hidden="true"><use href="assets/icons.svg#fullscreen"></use></svg>
     </button>
@@ -235,7 +235,7 @@ main
       <div id="boardLessonTitle" class="board-lesson-title" tabindex="0" aria-live="polite"></div>
     </div>
     <div class="board-header__date">
-      <button id="boardDate" class="board-date" type="button"></button>
+      <button id="boardDate" class="board-date" type="button" aria-label="Current date"></button>
     </div>
   </header>
 
@@ -282,9 +282,9 @@ main
       </div>
       <div id="stopwatchDisplay" class="stopwatch__display" aria-live="polite">00:00.00</div>
       <div class="stopwatch__controls">
-        <button id="stopwatchStart" type="button" class="stopwatch__button">Start</button>
-        <button id="stopwatchPause" type="button" class="stopwatch__button" disabled>Pause</button>
-        <button id="stopwatchReset" type="button" class="stopwatch__button" disabled>Reset</button>
+        <button id="stopwatchStart" type="button" class="stopwatch__button" aria-label="Start stopwatch">Start</button>
+        <button id="stopwatchPause" type="button" class="stopwatch__button" aria-label="Pause stopwatch" disabled>Pause</button>
+        <button id="stopwatchReset" type="button" class="stopwatch__button" aria-label="Reset stopwatch" disabled>Reset</button>
       </div>
     </div>
   </aside>
@@ -311,8 +311,14 @@ main
           autocomplete="off"
         ></textarea>
         <div class="practice-strip__actions">
-          <button class="practice-strip__button practice-strip__button--primary" type="submit">Apply</button>
-          <button class="practice-strip__button" type="button" id="practiceStripCancel">Cancel</button>
+          <button
+            class="practice-strip__button practice-strip__button--primary"
+            type="submit"
+            aria-label="Apply practice text"
+          >
+            Apply
+          </button>
+          <button class="practice-strip__button" type="button" id="practiceStripCancel" aria-label="Cancel practice text changes">Cancel</button>
         </div>
       </form>
     </section>
@@ -343,8 +349,14 @@ main
           Enter letters to start hidden. Characters are case-insensitive.
         </p>
         <div class="reveal-flyout__actions">
-          <button class="reveal-flyout__button reveal-flyout__button--primary" type="submit">Apply</button>
-          <button class="reveal-flyout__button" type="button" id="revealLettersCancel">Cancel</button>
+          <button
+            class="reveal-flyout__button reveal-flyout__button--primary"
+            type="submit"
+            aria-label="Apply hidden letters"
+          >
+            Apply
+          </button>
+          <button class="reveal-flyout__button" type="button" id="revealLettersCancel" aria-label="Cancel hidden letters changes">Cancel</button>
         </div>
       </form>
     </section>
@@ -372,8 +384,15 @@ main
           <div class="hide-letters__list" id="hideLettersList" role="group" aria-label="Letters"></div>
         </div>
         <footer class="hide-letters__footer">
-          <button type="button" class="hide-letters__action" id="hideLettersReset">Show all letters</button>
-          <button type="button" class="hide-letters__action hide-letters__action--primary" id="hideLettersDone">
+          <button type="button" class="hide-letters__action" id="hideLettersReset" aria-label="Show all letters">
+            Show all letters
+          </button>
+          <button
+            type="button"
+            class="hide-letters__action hide-letters__action--primary"
+            id="hideLettersDone"
+            aria-label="Close hide letters"
+          >
             Done
           </button>
         </footer>
@@ -387,11 +406,16 @@ main
       <div class="popover-section">
         <h2 class="popover-title">Guidelines</h2>
         <div class="style-grid" role="list">
-          <button class="style-option" type="button" data-page-style="blank">
+          <button class="style-option" type="button" data-page-style="blank" aria-label="Select blank guidelines">
             <span class="style-preview style-none" aria-hidden="true"></span>
             <span class="style-label">White</span>
           </button>
-          <button class="style-option" type="button" data-page-style="phonics-lines">
+          <button
+            class="style-option"
+            type="button"
+            data-page-style="phonics-lines"
+            aria-label="Select phonics lines guidelines"
+          >
             <span class="style-preview style-phonics-lines" aria-hidden="true"></span>
             <span class="style-label">Phonics lines</span>
           </button>
@@ -410,9 +434,13 @@ main
 
     <div id="timerMenu" class="popover" role="dialog" aria-label="Timer options">
       <div class="timer-grid">
-        <button class="timer-option" type="button" data-duration="60">1 minute</button>
-        <button class="timer-option" type="button" data-duration="120">2 minutes</button>
-        <button class="timer-option" type="button" data-action="stop">Stop timer</button>
+        <button class="timer-option" type="button" data-duration="60" aria-label="Set timer for 1 minute">
+          1 minute
+        </button>
+        <button class="timer-option" type="button" data-duration="120" aria-label="Set timer for 2 minutes">
+          2 minutes
+        </button>
+        <button class="timer-option" type="button" data-action="stop" aria-label="Stop timer">Stop timer</button>
       </div>
     </div>
 
@@ -434,8 +462,15 @@ main
           >.
         </p>
         <div class="cookie-popup__actions">
-          <button class="cookie-popup__button" id="cookieRejectButton" type="button">Reject</button>
-          <button class="cookie-popup__button cookie-popup__button--primary" id="cookieAcceptButton" type="button">
+          <button class="cookie-popup__button" id="cookieRejectButton" type="button" aria-label="Reject cookies">
+            Reject
+          </button>
+          <button
+            class="cookie-popup__button cookie-popup__button--primary"
+            id="cookieAcceptButton"
+            type="button"
+            aria-label="Accept cookies"
+          >
             Accept
           </button>
         </div>

--- a/js/Controls.js
+++ b/js/Controls.js
@@ -1016,6 +1016,7 @@ main
     const applyDate = () => {
       const formatted = formatDateWithOrdinal(new Date());
       this.boardDate.textContent = formatted;
+      this.boardDate.setAttribute('aria-label', `Current date ${formatted}`);
       this.setStorageItem('ui.dateText', formatted);
       this.queueBoardHeaderResize();
     };
@@ -1032,6 +1033,7 @@ main
         applyDate();
       } else {
         this.boardDate.textContent = storedDate;
+        this.boardDate.setAttribute('aria-label', `Current date ${storedDate}`);
         this.queueBoardHeaderResize();
       }
     } else {

--- a/js/main.js
+++ b/js/main.js
@@ -2342,6 +2342,18 @@ function setupLessonAndPracticePrompts() {
     }
   };
 
+  const requestRevealFlyoutSubmit = () => {
+    if (!revealLettersForm) {
+      return;
+    }
+
+    if (typeof revealLettersForm.requestSubmit === 'function') {
+      revealLettersForm.requestSubmit();
+    } else {
+      revealLettersForm.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    }
+  };
+
   const openRevealFlyout = () => {
     if (!revealLettersFlyout || !revealLettersButton || isRevealFlyoutOpen) {
       return;
@@ -2429,12 +2441,14 @@ function setupLessonAndPracticePrompts() {
       applyButton.type = 'submit';
       applyButton.className = 'practice-strip__button practice-strip__button--primary';
       applyButton.textContent = 'Apply';
+      applyButton.setAttribute('aria-label', 'Apply practice text');
 
       practiceStripCancel = document.createElement('button');
       practiceStripCancel.type = 'button';
       practiceStripCancel.id = 'practiceStripCancel';
       practiceStripCancel.className = 'practice-strip__button';
       practiceStripCancel.textContent = 'Cancel';
+      practiceStripCancel.setAttribute('aria-label', 'Cancel practice text changes');
 
       actions.appendChild(applyButton);
       actions.appendChild(practiceStripCancel);
@@ -2576,6 +2590,31 @@ function setupLessonAndPracticePrompts() {
     closePracticeStrip({ restoreFocus: true });
   });
 
+  const requestPracticeStripSubmit = () => {
+    if (!practiceStripForm) {
+      return;
+    }
+
+    if (typeof practiceStripForm.requestSubmit === 'function') {
+      practiceStripForm.requestSubmit();
+    } else {
+      practiceStripForm.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    }
+  };
+
+  practiceStripInput?.addEventListener('keydown', event => {
+    if (event.key === 'Enter' && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
+      event.preventDefault();
+      requestPracticeStripSubmit();
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closePracticeStrip({ restoreFocus: true });
+    }
+  });
+
   const handlePracticeStripDismiss = () => {
     closePracticeStrip({ restoreFocus: true });
   };
@@ -2621,6 +2660,19 @@ function setupLessonAndPracticePrompts() {
     event.preventDefault();
     applyHiddenLetters(revealLettersInput?.value ?? '');
     closeRevealFlyout({ restoreFocus: true });
+  });
+
+  revealLettersInput?.addEventListener('keydown', event => {
+    if (event.key === 'Enter' && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
+      event.preventDefault();
+      requestRevealFlyoutSubmit();
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeRevealFlyout({ restoreFocus: true });
+    }
   });
 
   revealLettersCancel?.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add accessible labels to all UI buttons and popover controls to clarify their purpose for assistive tech
- apply a shared :focus-visible outline so keyboard users get consistent focus feedback across button types
- enable Enter/Escape shortcuts for lesson title, practice text, and reveal dialogs while keeping the date button’s label in sync

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d55b4463f083319806d08671e0d1dd