### PR TITLE
Adjust fonts and fullscreen layout

### DIFF
--- a/css/fonts.css
+++ b/css/fonts.css
@@ -36,3 +36,20 @@
   src: url(https://fonts.gstatic.com/s/abeezee/v23/esDR31xSG-6AGleN2tWkkJUEGpA.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
+
+@font-face {
+  font-family: 'KG Primary Lined';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local('KG Primary Lined'), local('KGPrimaryLined');
+}
+
+@font-face {
+  font-family: 'Penman KG Lined';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local('Penman KG Lined'), local('PenmanKGLined'), local('KG Primary Penmanship Lined'),
+    local('KGPrimaryPenmanshipLined');
+}

--- a/css/style.css
+++ b/css/style.css
@@ -689,7 +689,8 @@ button:focus {
 #boardDate {
   pointer-events: auto;
   color: var(--color-smoky-black);
-  font-family: 'KG Primary', 'Comic Sans MS', 'Comic Sans', cursive;
+  font-family: 'Penman KG Lined', 'KG Primary Penmanship Lined', 'KG Primary Penmanship',
+    'KG Primary Lined', 'KG Primary', 'Comic Sans MS', 'Comic Sans', cursive;
   font-size: clamp(1.1rem, 1.2vw + 0.85rem, 2rem);
   font-weight: 700;
   letter-spacing: 0.05em;
@@ -719,7 +720,8 @@ button:focus {
 .board-lesson-title {
   pointer-events: none;
   color: var(--color-smoky-black);
-  font-family: 'KG Primary', 'Comic Sans MS', 'Comic Sans', cursive;
+  font-family: 'Penman KG Lined', 'KG Primary Penmanship Lined', 'KG Primary Penmanship',
+    'KG Primary Lined', 'KG Primary', 'Comic Sans MS', 'Comic Sans', cursive;
   font-size: clamp(2rem, 2vw + 1.35rem, 3.1rem);
   font-weight: 700;
   letter-spacing: 0.06em;
@@ -810,6 +812,25 @@ body.is-fullscreen .app-shell {
   background: var(--color-board-surround);
   border: none;
   border-radius: 0;
+  display: grid;
+  grid-template-columns: clamp(90px, 12vw, 160px) minmax(0, 1fr) clamp(90px, 12vw, 160px);
+  grid-template-rows: auto 1fr auto;
+  grid-template-areas:
+    'left header right'
+    'left board right'
+    'left bottom right';
+  column-gap: clamp(18px, 3vw, 32px);
+  row-gap: clamp(16px, 3vh, 32px);
+  align-items: start;
+}
+
+body.is-fullscreen .toolbar {
+  position: sticky;
+  top: clamp(16px, 4vh, 48px);
+  align-self: start;
+  max-height: calc(100vh - clamp(32px, 8vh, 96px) - var(--fullscreen-toolbar-offset, 0px));
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 body.is-fullscreen .writer-container {
@@ -872,6 +893,9 @@ body.is-fullscreen .board-header {
   align-items: flex-end;
   gap: clamp(16px, 4vw, 32px);
   box-sizing: border-box;
+  position: sticky;
+  top: clamp(16px, 4vh, 48px);
+  z-index: 40;
 }
 
 body.is-fullscreen #boardRegion {
@@ -1727,7 +1751,8 @@ body.is-fullscreen .board-palette {
   border: none;
   background: transparent;
   font-size: 1.1rem;
-  font-family: "KG Primary", "Comic Sans MS", "Comic Sans", cursive;
+  font-family: 'Penman KG Lined', 'KG Primary Penmanship Lined', 'KG Primary Penmanship',
+    'KG Primary Lined', 'KG Primary', 'Comic Sans MS', 'Comic Sans', cursive;
   color: var(--color-smoky-black);
   display: inline-flex;
   align-items: center;
@@ -1824,7 +1849,7 @@ body.is-fullscreen .board-palette {
   position: relative;
   font-size: clamp(64px, 12vw, 120px);
   line-height: 1;
-  font-family: "KG Primary", "Comic Sans MS", "Comic Sans", cursive;
+  font-family: 'KG Primary Lined', 'KG Primary', 'Comic Sans MS', 'Comic Sans', cursive;
   color: #111111;
 }
 
@@ -1851,7 +1876,9 @@ body.is-fullscreen .board-palette {
   align-items: flex-end;
   justify-content: center;
   opacity: 0;
-  transform: translateY(6%);
+  transform: none;
+  font-family: 'Penman KG Lined', 'KG Primary Penmanship Lined', 'KG Primary Penmanship',
+    'KG Primary Lined', 'KG Primary', 'Comic Sans MS', 'Comic Sans', cursive;
 }
 
 .teach-letter.is-revealed .teach-char {
@@ -1867,33 +1894,15 @@ body.is-fullscreen .board-palette {
   opacity: 0;
 }
 
-.teach-letter--uppercase {
-  color: #d8342c;
-}
-
-.teach-letter--descender {
-  color: #1e4dd8;
-}
-
-.teach-letter--period {
-  color: #1e4dd8;
-}
-
+.teach-letter--uppercase,
+.teach-letter--descender,
+.teach-letter--period,
 .teach-letter--default,
-.teach-letter--lowercase {
-  color: #111111;
-}
-
-.teach-letter--punctuation {
-  color: #1e4dd8;
-}
-
-.teach-letter--number {
-  color: #d8342c;
-}
-
+.teach-letter--lowercase,
+.teach-letter--punctuation,
+.teach-letter--number,
 .teach-letter--other {
-  color: #111111;
+  color: inherit;
 }
 .btn.icon {
   --glass-base: var(--control-button-surface);
@@ -2289,11 +2298,7 @@ body.is-fullscreen #toolbarBottom {
 }
 
 .style-preview.style-phonics-lines {
-  /* Keep in sync with PHONICS_LINES_ASSET_PATH in js/Controls.js */
-  background-image: url("../assets/icons/Phonics lines.svg");
-  background-repeat: no-repeat;
-  background-size: cover;
-  background-position: center;
+  background: rgba(255, 244, 213, 0.1);
 }
 
 .style-preview.style-grid::before,
@@ -3019,6 +3024,8 @@ body.info-panel-open {
   gap: 0.45rem;
   font-size: clamp(1.1rem, 1.8vw, 1.45rem);
   letter-spacing: 0.04em;
+  font-family: 'Penman KG Lined', 'KG Primary Penmanship Lined', 'KG Primary Penmanship',
+    'KG Primary Lined', 'KG Primary', 'Comic Sans MS', 'Comic Sans', cursive;
 }
 
 .practice-preview__letters br {
@@ -3036,7 +3043,7 @@ body.info-panel-open {
   border-radius: 14px;
   font-weight: 600;
   background: rgba(255, 255, 255, 0.14);
-  color: inherit;
+  color: #111111;
   transition: background 0.25s ease, color 0.25s ease, transform 0.25s ease, opacity 0.3s ease;
   position: relative;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);

--- a/js/Controls.js
+++ b/js/Controls.js
@@ -1,5 +1,5 @@
 import { DEFAULT_SETTINGS } from './UserData.js';
-import { formatDateWithOrdinal, clamp, getAssetUrl, loadImage, getLocalStorage } from './utils.js';
+import { formatDateWithOrdinal, clamp, getLocalStorage } from './utils.js';
 
 const CANVAS_WIDTH = 1200;
 const CANVAS_HEIGHT = 600;
@@ -33,11 +33,6 @@ const PEN_COLOUR_SWATCHES = [
 ];
 
 const RAINBOW_INDICATOR = 'conic-gradient(from 0deg, #ff004d, #ffa500, #ffee00, #00d084, #1e4dd8, #7f3f98, #ff004d)';
-
-const PHONICS_LINES_ASSET_PATH = 'icons/Phonics lines.svg';
-const PHONICS_LINES_IMAGE_SRC = getAssetUrl(PHONICS_LINES_ASSET_PATH);
-let phonicsLinesImage = null;
-let phonicsLinesImagePromise = null;
 
 const PAGE_STYLE_DRAWERS = {
   blank: clearBackground,
@@ -2503,43 +2498,8 @@ function clearBackground(ctx, width, height) {
   ctx.clearRect(0, 0, width, height);
 }
 
-function drawPhonicsLinesGuidelines(ctx, width, height, zoom = 1) {
+function drawPhonicsLinesGuidelines(ctx, width, height) {
+  ctx.save();
   ctx.clearRect(0, 0, width, height);
-
-  const drawImage = image => {
-    if (!image) {
-      return;
-    }
-
-    const scale = Number.isFinite(zoom) && zoom > 0 ? zoom : 1;
-    const drawWidth = width * scale;
-    const drawHeight = height * scale;
-    const offsetX = (width - drawWidth) / 2;
-    const offsetY = (height - drawHeight) / 2;
-
-    ctx.clearRect(0, 0, width, height);
-    ctx.drawImage(image, offsetX, offsetY, drawWidth, drawHeight);
-  };
-
-  if (phonicsLinesImage) {
-    drawImage(phonicsLinesImage);
-    return;
-  }
-
-  if (!phonicsLinesImagePromise) {
-    phonicsLinesImagePromise = loadImage(PHONICS_LINES_IMAGE_SRC)
-      .then(image => {
-        phonicsLinesImage = image;
-        return image;
-      })
-      .catch(error => {
-        console.warn(`Unable to load phonics lines background from "${PHONICS_LINES_ASSET_PATH}".`, error);
-        phonicsLinesImagePromise = null;
-        return null;
-      });
-  }
-
-  phonicsLinesImagePromise.then(image => {
-    drawImage(image);
-  });
+  ctx.restore();
 }

--- a/js/main.js
+++ b/js/main.js
@@ -2553,10 +2553,6 @@ function setupLessonAndPracticePrompts() {
 
   if (practiceButton) {
     practiceButton.addEventListener('click', () => {
-      if (!teachController) {
-        return;
-      }
-
       if (isPracticeStripOpen) {
         closePracticeStrip({ restoreFocus: false });
         return;
@@ -2564,7 +2560,7 @@ function setupLessonAndPracticePrompts() {
 
       const currentText =
         practiceState.text ||
-        teachController.getCurrentText?.() ||
+        teachController?.getCurrentText?.() ||
         controls.textInput?.value ||
         '';
 


### PR DESCRIPTION
## Summary
- swap the phonics guidelines background for a plain canvas and drop the unused asset loader
- keep lesson title and toolbars visible in fullscreen by reworking the layout grid and making the panels sticky
- switch hidden letter placeholders to KG Primary Lined with Penman KG Lined for revealed text, and fix the practice text prompt toggle

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5e2162d0483319df094256409e471